### PR TITLE
feat: support embedding model pricing

### DIFF
--- a/src/interfaces/aleph.py
+++ b/src/interfaces/aleph.py
@@ -14,12 +14,21 @@ class TextPricing(BaseModel):
     price_per_million_output_tokens: float
 
 
+class EmbeddingCapability(BaseModel):
+    context_window: int
+    dimensions: int
+
+
+class EmbeddingPricing(BaseModel):
+    price_per_million_input_tokens: float
+
+
 class ModelInfo(BaseModel):
     id: str
     name: str
     hf_id: str | None = None
-    capabilities: dict[str, TextCapability | bool]  # bool for image/search capability
-    pricing: dict[str, TextPricing | float]  # float for image/search pricing
+    capabilities: dict[str, TextCapability | EmbeddingCapability | bool]  # bool for image/search capability
+    pricing: dict[str, TextPricing | EmbeddingPricing | float]  # float for image/search pricing
 
 
 class RedirectionType(StrEnum):

--- a/src/services/aleph.py
+++ b/src/services/aleph.py
@@ -2,7 +2,7 @@ import time
 
 import aiohttp
 
-from src.interfaces.aleph import AlephAPIResponse, ModelInfo, TextPricing
+from src.interfaces.aleph import AlephAPIResponse, EmbeddingPricing, ModelInfo, TextPricing
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -97,6 +97,16 @@ class AlephService:
             input_price = input_tokens / 1_000_000 * pricing.price_per_million_input_tokens
             output_price = output_tokens / 1_000_000 * pricing.price_per_million_output_tokens
             total_price = input_price + output_price
+
+        # Embedding model pricing (input-only, no completion tokens)
+        elif "embedding" in model.pricing:
+            if image_count > 0:
+                raise ValueError(f"Embedding model {model_id} cannot process images")
+
+            pricing = model.pricing["embedding"]
+            if not isinstance(pricing, EmbeddingPricing):
+                raise ValueError(f"Invalid embedding pricing format for model: {model_id}")
+            total_price = input_tokens / 1_000_000 * pricing.price_per_million_input_tokens
 
         # Image model pricing
         elif "image" in model.pricing:

--- a/src/services/x402.py
+++ b/src/services/x402.py
@@ -3,7 +3,7 @@ import json
 import aiohttp
 
 from src.config import config
-from src.interfaces.aleph import TextPricing
+from src.interfaces.aleph import EmbeddingPricing, TextPricing
 from src.services.aleph import aleph_service
 from src.utils.logger import setup_logger
 
@@ -39,9 +39,17 @@ class X402Service:
                     "price_per_million_output_tokens": pricing.price_per_million_output_tokens,
                     "default_max_tokens": default_max_tokens,
                 }
+            elif "embedding" in model.pricing:
+                embedding_pricing = model.pricing["embedding"]
+                if not isinstance(embedding_pricing, EmbeddingPricing):
+                    continue
+                prices[model.id] = {
+                    "price_per_million_input_tokens": embedding_pricing.price_per_million_input_tokens,
+                    "is_embedding": True,
+                }
             elif "image" in model.pricing:
                 image_price = model.pricing["image"]
-                if isinstance(image_price, TextPricing):
+                if isinstance(image_price, (TextPricing, EmbeddingPricing)):
                     continue
                 prices[model.id] = {
                     "price_per_image": float(image_price),


### PR DESCRIPTION
## Summary
Adds a first-class **`embedding`** pricing kind (input-only) to the pricing backend, alongside the existing `text` / `image` / `search` kinds.

## Changes
- `interfaces/aleph.py`: `EmbeddingPricing` (`price_per_million_input_tokens`) + `EmbeddingCapability` (`context_window`, `dimensions`); widen `ModelInfo.pricing`/`capabilities` unions.
- `services/aleph.py` `calculate_price`: `embedding` branch — `input_tokens / 1M * price_per_million_input_tokens`, rejects images, ignores output tokens.
- `services/x402.py` `get_current_prices`: expose embedding models as `{price_per_million_input_tokens, is_embedding: true}` (consumed by libertai-api x402); exclude `EmbeddingPricing` from the image float-cast.

Usage ingestion (`/api-keys/admin/usage`) needs no change — non-image reports already flow through `calculate_price(input_tokens, output_tokens)`; the embedding branch handles output=0. `inference_calls` already stores input/output tokens (no migration).

## Verification
- `ruff check` ✓, `mypy` ✓ (3 files)

## Data note
The bge-m3 entry + its price must be added to the **Aleph `LTAI_PRICING` aggregate** (off-repo, owner-key) with `pricing: {"embedding": {"price_per_million_input_tokens": <n>}}`.
