### PR TITLE
refactor(stats): generic key_type routes + CLI analytics endpoints

### DIFF
--- a/src/interfaces/api_keys.py
+++ b/src/interfaces/api_keys.py
@@ -13,6 +13,19 @@ class ApiKeyType(str, Enum):
     cli = "cli"
 
 
+class InferenceKeyType(str, Enum):
+    """Key types whose usage is recorded in ``inference_calls`` (everything but chat).
+
+    Used as a stats route path param so global inference stats are served by a single
+    set of routes; invalid / chat values are rejected with HTTP 422 automatically.
+    """
+
+    api = "api"
+    liberclaw = "liberclaw"
+    x402 = "x402"
+    cli = "cli"
+
+
 class InferenceCallType(str, Enum):
     text = "text"
     image = "image"

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from fastapi import Depends, Query
 
+from src.interfaces.api_keys import ApiKeyType, InferenceKeyType
 from src.interfaces.stats import (
     DashboardStats,
     UsageStats,
@@ -44,40 +45,8 @@ async def get_usage_stats(
         raise
 
 
-@router.get("/global/api/credits", response_model=GlobalCreditsStats)  # type: ignore
-async def get_credits_stats(
-    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
-    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
-) -> GlobalCreditsStats:
-    try:
-        return await StatsService.get_global_credits_stats(start_date, end_date)
-    except Exception as e:
-        logger.error(f"Error in credits stats route: {str(e)}", exc_info=True)
-        raise
-
-
-@router.get("/global/api/calls", response_model=GlobalApiStats)  # type: ignore
-async def get_api_stats(
-    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
-    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
-) -> GlobalApiStats:
-    try:
-        return await StatsService.get_global_api_stats(start_date, end_date)
-    except Exception as e:
-        logger.error(f"Error in credits stats route: {str(e)}", exc_info=True)
-        raise
-
-
-@router.get("/global/api/tokens", response_model=GlobalTokensStats)  # type: ignore
-async def get_tokens_stats(
-    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
-    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
-) -> GlobalTokensStats:
-    try:
-        return await StatsService.get_global_tokens_stats(start_date, end_date)
-    except Exception as e:
-        logger.error(f"Error in token stats route: {str(e)}", exc_info=True)
-        raise
+# --- Chat stats: separate table (chat_requests), no key-type filter, no credits ---
+# Registered before the generic /global/{key_type}/... routes below.
 
 
 @router.get("/global/chat/calls", response_model=GlobalChatCallsStats)  # type: ignore
@@ -104,75 +73,45 @@ async def get_chat_tokens_stats(
         raise
 
 
-@router.get("/global/liberclaw/calls", response_model=GlobalApiStats)  # type: ignore
-async def get_liberclaw_calls_stats(
+# --- Generic inference stats: one set of routes for api / liberclaw / x402 / cli ---
+
+
+@router.get("/global/{key_type}/calls", response_model=GlobalApiStats)  # type: ignore
+async def get_inference_calls_stats(
+    key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
 ) -> GlobalApiStats:
     try:
-        return await StatsService.get_global_liberclaw_calls_stats(start_date, end_date)
+        return await StatsService._get_inference_api_stats(ApiKeyType(key_type.value), start_date, end_date)
     except Exception as e:
-        logger.error(f"Error in liberclaw calls stats route: {str(e)}", exc_info=True)
+        logger.error(f"Error in {key_type.value} calls stats route: {str(e)}", exc_info=True)
         raise
 
 
-@router.get("/global/liberclaw/tokens", response_model=GlobalTokensStats)  # type: ignore
-async def get_liberclaw_tokens_stats(
+@router.get("/global/{key_type}/tokens", response_model=GlobalTokensStats)  # type: ignore
+async def get_inference_tokens_stats(
+    key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
 ) -> GlobalTokensStats:
     try:
-        return await StatsService.get_global_liberclaw_tokens_stats(start_date, end_date)
+        return await StatsService._get_inference_tokens_stats(ApiKeyType(key_type.value), start_date, end_date)
     except Exception as e:
-        logger.error(f"Error in liberclaw tokens stats route: {str(e)}", exc_info=True)
+        logger.error(f"Error in {key_type.value} tokens stats route: {str(e)}", exc_info=True)
         raise
 
 
-@router.get("/global/liberclaw/credits", response_model=GlobalCreditsStats)  # type: ignore
-async def get_liberclaw_credits_stats(
+@router.get("/global/{key_type}/credits", response_model=GlobalCreditsStats)  # type: ignore
+async def get_inference_credits_stats(
+    key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
 ) -> GlobalCreditsStats:
     try:
-        return await StatsService.get_global_liberclaw_credits_stats(start_date, end_date)
+        return await StatsService._get_inference_credits_stats(ApiKeyType(key_type.value), start_date, end_date)
     except Exception as e:
-        logger.error(f"Error in liberclaw credits stats route: {str(e)}", exc_info=True)
-        raise
-
-
-@router.get("/global/x402/calls", response_model=GlobalApiStats)  # type: ignore
-async def get_x402_calls_stats(
-    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
-    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
-) -> GlobalApiStats:
-    try:
-        return await StatsService.get_global_x402_calls_stats(start_date, end_date)
-    except Exception as e:
-        logger.error(f"Error in x402 calls stats route: {str(e)}", exc_info=True)
-        raise
-
-
-@router.get("/global/x402/tokens", response_model=GlobalTokensStats)  # type: ignore
-async def get_x402_tokens_stats(
-    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
-    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
-) -> GlobalTokensStats:
-    try:
-        return await StatsService.get_global_x402_tokens_stats(start_date, end_date)
-    except Exception as e:
-        logger.error(f"Error in x402 tokens stats route: {str(e)}", exc_info=True)
-        raise
-
-
-@router.get("/global/x402/credits", response_model=GlobalCreditsStats)  # type: ignore
-async def get_x402_credits_stats(
-    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
-    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
-) -> GlobalCreditsStats:
-    try:
-        return await StatsService.get_global_x402_credits_stats(start_date, end_date)
-    except Exception as e:
-        logger.error(f"Error in x402 credits stats route: {str(e)}", exc_info=True)
+        logger.error(f"Error in {key_type.value} credits stats route: {str(e)}", exc_info=True)
         raise
 
 

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -286,14 +286,6 @@ class StatsService:
             return GlobalCreditsStats(total_credits_used=total, credits_usage=credits_usage)
 
     @staticmethod
-    async def get_global_credits_stats(start_date: date, end_date: date) -> GlobalCreditsStats:
-        try:
-            return await StatsService._get_inference_credits_stats(ApiKeyType.api, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving credits stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
     async def _get_inference_api_stats(key_type: ApiKeyType, start_date: date, end_date: date) -> GlobalApiStats:
         async with AsyncSessionLocal() as db:
             start_datetime = datetime.combine(start_date, datetime.min.time())
@@ -331,14 +323,6 @@ class StatsService:
                 )
 
             return GlobalApiStats(total_calls=total, api_usage=api_usage)
-
-    @staticmethod
-    async def get_global_api_stats(start_date: date, end_date: date) -> GlobalApiStats:
-        try:
-            return await StatsService._get_inference_api_stats(ApiKeyType.api, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving api stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
 
     @staticmethod
     async def _get_inference_tokens_stats(key_type: ApiKeyType, start_date: date, end_date: date) -> GlobalTokensStats:
@@ -383,14 +367,6 @@ class StatsService:
                 )
 
             return GlobalTokensStats(total_input_tokens=total_input, total_output_tokens=total_output, calls=calls)
-
-    @staticmethod
-    async def get_global_tokens_stats(start_date: date, end_date: date) -> GlobalTokensStats:
-        try:
-            return await StatsService._get_inference_tokens_stats(ApiKeyType.api, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving token stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
 
     @staticmethod
     async def get_global_chat_calls_stats(start_date: date, end_date: date) -> GlobalChatCallsStats:
@@ -481,54 +457,6 @@ class StatsService:
                 )
         except Exception as e:
             logger.error(f"Error retrieving chat token stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
-    async def get_global_liberclaw_calls_stats(start_date: date, end_date: date) -> GlobalApiStats:
-        try:
-            return await StatsService._get_inference_api_stats(ApiKeyType.liberclaw, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving liberclaw calls stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
-    async def get_global_liberclaw_tokens_stats(start_date: date, end_date: date) -> GlobalTokensStats:
-        try:
-            return await StatsService._get_inference_tokens_stats(ApiKeyType.liberclaw, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving liberclaw token stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
-    async def get_global_liberclaw_credits_stats(start_date: date, end_date: date) -> GlobalCreditsStats:
-        try:
-            return await StatsService._get_inference_credits_stats(ApiKeyType.liberclaw, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving liberclaw credits stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
-    async def get_global_x402_calls_stats(start_date: date, end_date: date) -> GlobalApiStats:
-        try:
-            return await StatsService._get_inference_api_stats(ApiKeyType.x402, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving x402 calls stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
-    async def get_global_x402_tokens_stats(start_date: date, end_date: date) -> GlobalTokensStats:
-        try:
-            return await StatsService._get_inference_tokens_stats(ApiKeyType.x402, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving x402 token stats: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    @staticmethod
-    async def get_global_x402_credits_stats(start_date: date, end_date: date) -> GlobalCreditsStats:
-        try:
-            return await StatsService._get_inference_credits_stats(ApiKeyType.x402, start_date, end_date)
-        except Exception as e:
-            logger.error(f"Error retrieving x402 credits stats: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")
 
     @staticmethod


### PR DESCRIPTION
## What

Collapses the 9 duplicated `api`/`liberclaw`/`x402` global stats routes (and their thin service wrappers) into **3 generic routes**:

```
GET /stats/global/{key_type}/calls
GET /stats/global/{key_type}/tokens
GET /stats/global/{key_type}/credits
```

`key_type` is validated against a new `InferenceKeyType` enum `{api, liberclaw, x402, cli}` (invalid / `chat` values → 422). Chat stats stay on explicit routes (separate table, tracks cached tokens, no credits column).

## Why

This exposes **CLI** analytics (`cli` keys already write to `inference_calls`) without any new per-type boilerplate, and removes ~120 lines of copy-paste. Existing public URLs (`/stats/global/x402/calls`, etc.) are unchanged.

## Verification

- Live queries against the dev DB return correct shapes for `api`/`x402`/`liberclaw`/`cli`/`chat`.
- Invalid and `chat` key types correctly 422 on the generic route.
- `ruff check`, `ruff format --check`, and `mypy` pass on the changed files.

Paired with the frontend PR in libertai-analytics.