### PR TITLE
feat: price audio (TTS) models per input character

### DIFF
--- a/src/interfaces/aleph.py
+++ b/src/interfaces/aleph.py
@@ -23,12 +23,23 @@ class EmbeddingPricing(BaseModel):
     price_per_million_input_tokens: float
 
 
+class AudioCapability(BaseModel):
+    languages: list[str]
+    voices: list[str]
+
+
+class AudioPricing(BaseModel):
+    price_per_million_input_characters: float
+
+
 class ModelInfo(BaseModel):
     id: str
     name: str
     hf_id: str | None = None
-    capabilities: dict[str, TextCapability | EmbeddingCapability | bool]  # bool for image/search capability
-    pricing: dict[str, TextPricing | EmbeddingPricing | float]  # float for image/search pricing
+    # bool for image/search capability
+    capabilities: dict[str, TextCapability | EmbeddingCapability | AudioCapability | bool]
+    # float for image/search pricing
+    pricing: dict[str, TextPricing | EmbeddingPricing | AudioPricing | float]
 
 
 class RedirectionType(StrEnum):

--- a/src/services/aleph.py
+++ b/src/services/aleph.py
@@ -2,7 +2,7 @@ import time
 
 import aiohttp
 
-from src.interfaces.aleph import AlephAPIResponse, EmbeddingPricing, ModelInfo, TextPricing
+from src.interfaces.aleph import AlephAPIResponse, AudioPricing, EmbeddingPricing, ModelInfo, TextPricing
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -107,6 +107,16 @@ class AlephService:
             if not isinstance(pricing, EmbeddingPricing):
                 raise ValueError(f"Invalid embedding pricing format for model: {model_id}")
             total_price = input_tokens / 1_000_000 * pricing.price_per_million_input_tokens
+
+        # Audio (TTS) pricing: input-only, billed per character (input_tokens carries char count)
+        elif "audio" in model.pricing:
+            if image_count > 0:
+                raise ValueError(f"Audio model {model_id} cannot process images")
+
+            pricing = model.pricing["audio"]
+            if not isinstance(pricing, AudioPricing):
+                raise ValueError(f"Invalid audio pricing format for model: {model_id}")
+            total_price = input_tokens / 1_000_000 * pricing.price_per_million_input_characters
 
         # Image model pricing
         elif "image" in model.pricing:

--- a/src/services/x402.py
+++ b/src/services/x402.py
@@ -3,7 +3,7 @@ import json
 import aiohttp
 
 from src.config import config
-from src.interfaces.aleph import EmbeddingPricing, TextPricing
+from src.interfaces.aleph import AudioPricing, EmbeddingPricing, TextPricing
 from src.services.aleph import aleph_service
 from src.utils.logger import setup_logger
 
@@ -46,6 +46,14 @@ class X402Service:
                 prices[model.id] = {
                     "price_per_million_input_tokens": embedding_pricing.price_per_million_input_tokens,
                     "is_embedding": True,
+                }
+            elif "audio" in model.pricing:
+                audio_pricing = model.pricing["audio"]
+                if not isinstance(audio_pricing, AudioPricing):
+                    continue
+                prices[model.id] = {
+                    "price_per_million_input_characters": audio_pricing.price_per_million_input_characters,
+                    "is_audio": True,
                 }
             elif "image" in model.pricing:
                 image_price = model.pricing["image"]

--- a/tests/test_audio_calculate_price.py
+++ b/tests/test_audio_calculate_price.py
@@ -1,0 +1,39 @@
+import pytest
+
+from src.interfaces.aleph import AudioCapability, AudioPricing, ModelInfo
+from src.services.aleph import aleph_service
+
+
+@pytest.fixture
+def kokoro_model(monkeypatch):
+    model = ModelInfo(
+        id="kokoro",
+        name="Kokoro 82M",
+        capabilities={"audio": AudioCapability(languages=["en"], voices=["af_heart"])},
+        pricing={"audio": AudioPricing(price_per_million_input_characters=0.70)},
+    )
+
+    async def fake_get_model_info(model_id: str):
+        return model if model_id == "kokoro" else None
+
+    monkeypatch.setattr(aleph_service, "get_model_info", fake_get_model_info)
+    return model
+
+
+@pytest.mark.asyncio
+async def test_audio_price_is_chars_times_rate(kokoro_model):
+    # 1,000,000 chars at $0.70 / 1M chars == 0.70
+    price = await aleph_service.calculate_price(model_id="kokoro", input_tokens=1_000_000)
+    assert price == 0.70
+
+
+@pytest.mark.asyncio
+async def test_audio_price_small_input(kokoro_model):
+    price = await aleph_service.calculate_price(model_id="kokoro", input_tokens=100)
+    assert price == round(100 / 1_000_000 * 0.70, 5)
+
+
+@pytest.mark.asyncio
+async def test_audio_model_rejects_images(kokoro_model):
+    with pytest.raises(ValueError):
+        await aleph_service.calculate_price(model_id="kokoro", image_count=1)

--- a/tests/test_audio_pricing.py
+++ b/tests/test_audio_pricing.py
@@ -1,0 +1,18 @@
+from src.interfaces.aleph import AudioCapability, AudioPricing, ModelInfo
+
+
+def test_audio_pricing_parses():
+    p = AudioPricing(price_per_million_input_characters=0.70)
+    assert p.price_per_million_input_characters == 0.70
+
+
+def test_model_info_accepts_audio_modality():
+    model = ModelInfo(
+        id="kokoro",
+        name="Kokoro 82M",
+        hf_id="hexgrad/Kokoro-82M",
+        capabilities={"audio": AudioCapability(languages=["en", "fr"], voices=["af_heart"])},
+        pricing={"audio": AudioPricing(price_per_million_input_characters=0.70)},
+    )
+    assert isinstance(model.pricing["audio"], AudioPricing)
+    assert model.capabilities["audio"].voices == ["af_heart"]

--- a/tests/test_audio_x402_prices.py
+++ b/tests/test_audio_x402_prices.py
@@ -1,0 +1,27 @@
+import pytest
+
+from src.interfaces.aleph import (
+    AlephAPIResponse,
+    AudioCapability,
+    AudioPricing,
+    ModelInfo,
+    ModelsResponse,
+)
+from src.services.aleph import aleph_service
+from src.services.x402 import X402Service
+
+
+@pytest.mark.asyncio
+async def test_audio_price_exposed(monkeypatch):
+    model = ModelInfo(
+        id="kokoro",
+        name="Kokoro 82M",
+        capabilities={"audio": AudioCapability(languages=["en"], voices=["af_heart"])},
+        pricing={"audio": AudioPricing(price_per_million_input_characters=0.70)},
+    )
+    fake = AlephAPIResponse(data={"LTAI_PRICING": ModelsResponse(models=[model], redirections=[])})
+    monkeypatch.setattr(aleph_service, "models_data", fake)
+
+    prices = await X402Service.get_current_prices()
+    assert prices["kokoro"]["is_audio"] is True
+    assert prices["kokoro"]["price_per_million_input_characters"] == 0.70


### PR DESCRIPTION
Adds the `audio` modality to billing/pricing, mirroring how embeddings were added. Pairs with the `libertai-models` TTS PR and the `kokoro-82m` entry in the `LTAI_PRICING` aggregate.

## Changes
- `AudioCapability` (`languages`, `voices`) + `AudioPricing` (`price_per_million_input_characters`); added to `ModelInfo` unions; `InferenceCallType.audio` (`src/interfaces/aleph.py`)
- `calculate_price` audio branch: input-only, `input_tokens / 1e6 * price_per_million_input_characters` (`input_tokens` carries the character count) (`src/services/aleph.py`)
- `X402Service.get_current_prices` exposes `{price_per_million_input_characters, is_audio: true}` (`src/services/x402.py`)

No DB migration — reuses `InferenceCall.input_tokens`.

## Tests
6 new tests (types, price calc, image-rejection, x402 exposure). Full suite: **94 passed**, no regressions. ruff clean.