### PR TITLE
feat(api-keys): warm API-key pool to eliminate ~30s propagation delay

### DIFF
--- a/alembic/versions/c1d2e3f4a5b6_add_pool_to_apikeytype_enum.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_pool_to_apikeytype_enum.py
@@ -1,0 +1,29 @@
+"""add pool to apikeytype enum
+
+Revision ID: c1d2e3f4a5b6
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("ALTER TYPE apikeytype ADD VALUE IF NOT EXISTS 'pool'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # PostgreSQL doesn't support removing values from enums
+    pass

--- a/src/config.py
+++ b/src/config.py
@@ -73,6 +73,12 @@ class _Config:
     # subscriptions, API access is gated on prepaid balance only.
     SUBSCRIPTIONS_ENABLED: bool
 
+    # Warm API-key pool: keys pre-created and pre-propagated to instances so a freshly
+    # "created" key is recognized immediately (no ~30s propagation wait).
+    POOL_SIZE: int
+    POOL_WARM_THRESHOLD_SECONDS: int
+    POOL_RECONCILE_INTERVAL_SECONDS: int
+
     # Provider-agnostic fiat payments (Revolut first)
     REVOLUT_SECRET_KEY: str
     REVOLUT_WEBHOOK_SECRET: str
@@ -154,6 +160,11 @@ class _Config:
         self.JWT_REFRESH_TOKEN_EXPIRE_DAYS = int(os.getenv("JWT_REFRESH_TOKEN_EXPIRE_DAYS", "30"))
 
         self.SUBSCRIPTIONS_ENABLED = os.getenv("SUBSCRIPTIONS_ENABLED", "False").lower() == "true"
+
+        # Warm API-key pool
+        self.POOL_SIZE = int(os.getenv("POOL_SIZE", "5"))
+        self.POOL_WARM_THRESHOLD_SECONDS = int(os.getenv("POOL_WARM_THRESHOLD_SECONDS", "60"))
+        self.POOL_RECONCILE_INTERVAL_SECONDS = int(os.getenv("POOL_RECONCILE_INTERVAL_SECONDS", "300"))
 
         # Payments (Revolut)
         self.REVOLUT_SECRET_KEY = os.getenv("REVOLUT_SECRET_KEY", "")

--- a/src/interfaces/api_keys.py
+++ b/src/interfaces/api_keys.py
@@ -11,6 +11,7 @@ class ApiKeyType(str, Enum):
     liberclaw = "liberclaw"
     x402 = "x402"
     cli = "cli"
+    pool = "pool"
 
 
 class InferenceKeyType(str, Enum):

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -12,6 +12,7 @@ from src.interfaces.api_keys import ApiKey, FullApiKey, ApiKeyType
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.inference_call import InferenceCall
+from src.services.api_key_pool import ApiKeyPoolService
 from src.services.credit import CreditService
 from src.services.entitlement import (
     WINDOW_5H,
@@ -78,18 +79,33 @@ class ApiKeyService:
                     await db.rollback()
                     raise ValueError(f"API key with name '{name}' already exists")
 
-                # Create new API key
-                key = ApiKeyDB.generate_key()
-                api_key = ApiKeyDB(
-                    key=key,
-                    name=name,
+                # Prefer a pre-warmed pool key (already propagated to instances);
+                # fall back to cold generation when none is ready.
+                claimed = await ApiKeyPoolService.claim_warm_key(
+                    db,
+                    target_type=key_type,
                     user_id=user_id,
-                    user_address=user_address,
+                    name=name,
                     monthly_limit=monthly_limit,
-                    type=key_type,
+                    user_address=user_address,
                 )
-                db.add(api_key)
+                if claimed is not None:
+                    api_key = claimed
+                else:
+                    api_key = ApiKeyDB(
+                        key=ApiKeyDB.generate_key(),
+                        name=name,
+                        user_id=user_id,
+                        user_address=user_address,
+                        monthly_limit=monthly_limit,
+                        type=key_type,
+                    )
+                    db.add(api_key)
+                key = api_key.key
                 await db.commit()
+
+                if claimed is not None:
+                    ApiKeyPoolService.schedule_refill()
 
                 # Create a clean detached copy of the object with all required attributes
                 # For newly created keys, we DO want to return the full key

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -289,18 +289,32 @@ class ApiKeyService:
                         type=existing_key.type,
                     )
 
-                # Create new chat API key
-                key = ApiKeyDB.generate_key()
-                api_key = ApiKeyDB(
-                    key=key,
-                    name="Chat API Key",
+                # Create new chat API key — prefer a pre-warmed pool key.
+                claimed = await ApiKeyPoolService.claim_warm_key(
+                    db,
+                    target_type=ApiKeyType.chat,
                     user_id=user_id,
-                    user_address=user_address,
+                    name="Chat API Key",
                     monthly_limit=None,
-                    type=ApiKeyType.chat,
+                    user_address=user_address,
                 )
-                db.add(api_key)
+                if claimed is not None:
+                    api_key = claimed
+                else:
+                    api_key = ApiKeyDB(
+                        key=ApiKeyDB.generate_key(),
+                        name="Chat API Key",
+                        user_id=user_id,
+                        user_address=user_address,
+                        monthly_limit=None,
+                        type=ApiKeyType.chat,
+                    )
+                    db.add(api_key)
+                key = api_key.key
                 await db.commit()
+
+                if claimed is not None:
+                    ApiKeyPoolService.schedule_refill()
 
                 return FullApiKey(
                     id=api_key.id,

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -158,24 +158,44 @@ class ApiKeyService:
                     .first()
                 )
 
-                key = ApiKeyDB.generate_key()
+                claimed = False
                 if existing is not None:
                     # Rotate in place: same row (and usage history), new secret + expiry.
-                    existing.key = key
+                    # Adopt a warm string if one is ready; the pool row is deleted first
+                    # (inside claim_warm_string) so UNIQUE(key) is never violated.
+                    warm = await ApiKeyPoolService.claim_warm_string(db)
+                    existing.key = warm if warm is not None else ApiKeyDB.generate_key()
                     existing.expires_at = expires_at
                     existing.is_active = True
                     api_key = existing
+                    claimed = warm is not None
                 else:
-                    api_key = ApiKeyDB(
-                        key=key,
-                        name=name,
+                    pool_row = await ApiKeyPoolService.claim_warm_key(
+                        db,
+                        target_type=ApiKeyType.cli,
                         user_id=user_id,
+                        name=name,
                         user_address=user_address,
-                        type=ApiKeyType.cli,
                         expires_at=expires_at,
                     )
-                    db.add(api_key)
+                    if pool_row is not None:
+                        api_key = pool_row
+                        claimed = True
+                    else:
+                        api_key = ApiKeyDB(
+                            key=ApiKeyDB.generate_key(),
+                            name=name,
+                            user_id=user_id,
+                            user_address=user_address,
+                            type=ApiKeyType.cli,
+                            expires_at=expires_at,
+                        )
+                        db.add(api_key)
+                key = api_key.key
                 await db.commit()
+
+                if claimed:
+                    ApiKeyPoolService.schedule_refill()
 
                 return FullApiKey(
                     id=api_key.id,

--- a/src/services/api_key_pool.py
+++ b/src/services/api_key_pool.py
@@ -1,0 +1,61 @@
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.sql import func as sql_func
+
+from src.config import config
+from src.interfaces.api_keys import ApiKeyType
+from src.models.api_key import ApiKey as ApiKeyDB
+from src.models.base import AsyncSessionLocal
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# Sentinel name for unclaimed pool rows. `api_keys.name` is NOT NULL, so pool rows
+# need a placeholder; it is overwritten with the user's name on claim. Multiple pool
+# rows sharing this name do not violate the legacy (user_address, name) unique
+# constraint because user_address is NULL (NULLs are distinct in PG unique indexes).
+POOL_SENTINEL_NAME = "__pool__"
+
+# Serialize refills so two concurrent top-ups don't both observe a stale count and
+# overshoot. A little overshoot is harmless, but the lock keeps the pool size exact.
+_refill_lock = asyncio.Lock()
+
+# Keep strong refs to fire-and-forget refill tasks so they aren't GC'd mid-flight.
+_pending_refills: set[asyncio.Task] = set()
+
+
+class ApiKeyPoolService:
+    @staticmethod
+    async def ensure_pool() -> int:
+        """Top the pool back up to config.POOL_SIZE. Idempotent. Returns how many were created."""
+        try:
+            async with _refill_lock:
+                async with AsyncSessionLocal() as db:
+                    count = int(
+                        (
+                            await db.execute(
+                                select(sql_func.count())
+                                .select_from(ApiKeyDB)
+                                .where(ApiKeyDB.type == ApiKeyType.pool)
+                            )
+                        ).scalar()
+                        or 0
+                    )
+                    deficit = config.POOL_SIZE - count
+                    if deficit <= 0:
+                        return 0
+                    for _ in range(deficit):
+                        db.add(
+                            ApiKeyDB(
+                                key=ApiKeyDB.generate_key(),
+                                name=POOL_SENTINEL_NAME,
+                                type=ApiKeyType.pool,
+                            )
+                        )
+                    await db.commit()
+                    logger.info(f"Warm pool topped up by {deficit} (target {config.POOL_SIZE})")
+                    return deficit
+        except Exception as e:
+            logger.error(f"Error ensuring warm API-key pool: {str(e)}", exc_info=True)
+            return 0

--- a/src/services/api_key_pool.py
+++ b/src/services/api_key_pool.py
@@ -107,3 +107,36 @@ class ApiKeyPoolService:
         row.deleted_at = None
         row.created_at = datetime.now()
         return row
+
+    @staticmethod
+    async def claim_warm_string(db) -> str | None:
+        """Claim a warm pool key as a raw string and delete its pool row, for callers
+        that must keep an existing row (CLI rotation adopts the warm string into the
+        pre-existing CLI row to preserve usage history). Runs in the caller's
+        transaction. The deleted pool row is flushed before the caller reassigns the
+        string elsewhere, so the UNIQUE(key) constraint is never momentarily violated.
+        """
+        ready_before = datetime.now() - timedelta(seconds=config.POOL_WARM_THRESHOLD_SECONDS)
+        stmt = (
+            select(ApiKeyDB)
+            .where(ApiKeyDB.type == ApiKeyType.pool, ApiKeyDB.created_at < ready_before)
+            .order_by(ApiKeyDB.created_at.asc())
+            .limit(1)
+            .with_for_update(skip_locked=True)
+        )
+        row = (await db.execute(stmt)).scalars().first()
+        if row is None:
+            return None
+        key = row.key
+        await db.delete(row)
+        await db.flush()
+        return key
+
+    @staticmethod
+    def schedule_refill() -> asyncio.Task:
+        """Fire-and-forget refill of the pool back to POOL_SIZE. Returns the task so
+        callers/tests can await it; production callers ignore the return value."""
+        task = asyncio.create_task(ApiKeyPoolService.ensure_pool())
+        _pending_refills.add(task)
+        task.add_done_callback(_pending_refills.discard)
+        return task

--- a/src/services/api_key_pool.py
+++ b/src/services/api_key_pool.py
@@ -1,4 +1,6 @@
 import asyncio
+import uuid
+from datetime import datetime, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.sql import func as sql_func
@@ -59,3 +61,47 @@ class ApiKeyPoolService:
         except Exception as e:
             logger.error(f"Error ensuring warm API-key pool: {str(e)}", exc_info=True)
             return 0
+
+    @staticmethod
+    async def claim_warm_key(
+        db,
+        *,
+        target_type: ApiKeyType,
+        name: str,
+        user_id: uuid.UUID | None = None,
+        monthly_limit: float | None = None,
+        user_address: str | None = None,
+        expires_at: datetime | None = None,
+        liberclaw_user_id: uuid.UUID | None = None,
+    ) -> ApiKeyDB | None:
+        """Atomically claim the oldest pool row that has been alive long enough to have
+        propagated, repurposing it into the target key. Runs inside the caller's
+        transaction (the caller commits). Returns the claimed row, or None if no warm
+        pool key is ready (caller should fall back to cold generation).
+
+        Concurrency: SELECT ... FOR UPDATE SKIP LOCKED guarantees two simultaneous
+        claims never grab the same row. created_at is reset to now() so the
+        user-facing creation time is correct; the warmth came from the key string
+        already being in the whitelist, independent of created_at.
+        """
+        ready_before = datetime.now() - timedelta(seconds=config.POOL_WARM_THRESHOLD_SECONDS)
+        stmt = (
+            select(ApiKeyDB)
+            .where(ApiKeyDB.type == ApiKeyType.pool, ApiKeyDB.created_at < ready_before)
+            .order_by(ApiKeyDB.created_at.asc())
+            .limit(1)
+            .with_for_update(skip_locked=True)
+        )
+        row = (await db.execute(stmt)).scalars().first()
+        if row is None:
+            return None
+
+        row.type = target_type
+        row.user_id = user_id
+        row.name = name
+        row.monthly_limit = monthly_limit
+        row.user_address = user_address
+        row.expires_at = expires_at
+        row.liberclaw_user_id = liberclaw_user_id
+        row.created_at = datetime.now()
+        return row

--- a/src/services/api_key_pool.py
+++ b/src/services/api_key_pool.py
@@ -48,13 +48,13 @@ class ApiKeyPoolService:
                     if deficit <= 0:
                         return 0
                     for _ in range(deficit):
-                        db.add(
-                            ApiKeyDB(
-                                key=ApiKeyDB.generate_key(),
-                                name=POOL_SENTINEL_NAME,
-                                type=ApiKeyType.pool,
-                            )
+                        row = ApiKeyDB(
+                            key=ApiKeyDB.generate_key(),
+                            name=POOL_SENTINEL_NAME,
+                            type=ApiKeyType.pool,
                         )
+                        row.created_at = datetime.now()
+                        db.add(row)
                     await db.commit()
                     logger.info(f"Warm pool topped up by {deficit} (target {config.POOL_SIZE})")
                     return deficit
@@ -103,5 +103,7 @@ class ApiKeyPoolService:
         row.user_address = user_address
         row.expires_at = expires_at
         row.liberclaw_user_id = liberclaw_user_id
+        row.is_active = True
+        row.deleted_at = None
         row.created_at = datetime.now()
         return row

--- a/src/services/liberclaw.py
+++ b/src/services/liberclaw.py
@@ -11,6 +11,7 @@ from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.inference_call import InferenceCall
 from src.models.liberclaw_user import LiberclawUser
+from src.services.api_key_pool import ApiKeyPoolService
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -54,15 +55,27 @@ class LiberclawService:
             if existing_key:
                 return LiberclawApiKeyResponse(key=existing_key.key, is_new=False)
 
-            key = ApiKeyDB.generate_key()
-            api_key = ApiKeyDB(
-                key=key,
+            claimed = await ApiKeyPoolService.claim_warm_key(
+                db,
+                target_type=ApiKeyType.liberclaw,
                 name=f"liberclaw-{user_id}",
-                type=ApiKeyType.liberclaw,
                 liberclaw_user_id=lc_user.id,
             )
-            db.add(api_key)
+            if claimed is not None:
+                api_key = claimed
+            else:
+                api_key = ApiKeyDB(
+                    key=ApiKeyDB.generate_key(),
+                    name=f"liberclaw-{user_id}",
+                    type=ApiKeyType.liberclaw,
+                    liberclaw_user_id=lc_user.id,
+                )
+                db.add(api_key)
+            key = api_key.key
             await db.commit()
+
+            if claimed is not None:
+                ApiKeyPoolService.schedule_refill()
 
             return LiberclawApiKeyResponse(key=key, is_new=True)
 

--- a/src/utils/cron.py
+++ b/src/utils/cron.py
@@ -12,10 +12,20 @@ ltai_solana_payments_lock = asyncio.Lock()
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
+    from src.config import config
     from src.services.aleph import aleph_service
+    from src.services.api_key_pool import ApiKeyPoolService
     from src.utils.token import close_async_client
 
     await aleph_service.fetch_models_data()
+    # Seed the warm API-key pool so the first creations after boot are already propagated.
+    await ApiKeyPoolService.ensure_pool()
+    # Safety net: re-assert the pool size periodically in case a background refill failed.
+    scheduler.add_job(
+        ApiKeyPoolService.ensure_pool,
+        "interval",
+        seconds=config.POOL_RECONCILE_INTERVAL_SECONDS,
+    )
     scheduler.start()
     yield
     scheduler.shutdown()

--- a/tests/test_admin_list_enforcement.py
+++ b/tests/test_admin_list_enforcement.py
@@ -154,6 +154,26 @@ async def test_prepaid_not_charged_while_within_window_then_charged_on_overflow(
         await _cleanup(user_id)
 
 
+async def test_pool_keys_are_included_in_whitelist_unconditionally():
+    """Unclaimed pool keys must ride in the whitelist (no owner, no credits) so they
+    propagate to instances and are warm by the time they're claimed."""
+    from src.services.api_key_pool import POOL_SENTINEL_NAME
+
+    async with AsyncSessionLocal() as db:
+        pool_key = ApiKeyDB.generate_key()
+        row = ApiKeyDB(key=pool_key, name=POOL_SENTINEL_NAME, type=ApiKeyType.pool)
+        db.add(row)
+        await db.commit()
+    try:
+        assert pool_key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        async with AsyncSessionLocal() as db:
+            from sqlalchemy import delete
+
+            await db.execute(delete(ApiKeyDB).where(ApiKeyDB.key == pool_key))
+            await db.commit()
+
+
 async def _balance(user_id) -> float:
     from sqlalchemy import func, select
 

--- a/tests/test_api_key_pool.py
+++ b/tests/test_api_key_pool.py
@@ -1,0 +1,81 @@
+"""Unit tests for the warm API-key pool service.
+
+These exercise ApiKeyPoolService against the committed test DB (the service opens
+its own AsyncSessionLocal), so each test clears the pool before and after itself.
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import delete, func, select
+
+from src.interfaces.api_keys import ApiKeyType
+from src.models.api_key import ApiKey as ApiKeyDB
+from src.models.base import AsyncSessionLocal
+from src.services.api_key_pool import ApiKeyPoolService, POOL_SENTINEL_NAME
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _pool_count() -> int:
+    async with AsyncSessionLocal() as db:
+        return int(
+            (
+                await db.execute(
+                    select(func.count()).select_from(ApiKeyDB).where(ApiKeyDB.type == ApiKeyType.pool)
+                )
+            ).scalar()
+            or 0
+        )
+
+
+async def _add_pool_key(*, age_seconds: int) -> str:
+    """Insert a pool row whose created_at is `age_seconds` in the past. Returns its key."""
+    async with AsyncSessionLocal() as db:
+        key = ApiKeyDB.generate_key()
+        row = ApiKeyDB(key=key, name=POOL_SENTINEL_NAME, type=ApiKeyType.pool)
+        row.created_at = datetime.now() - timedelta(seconds=age_seconds)
+        db.add(row)
+        await db.commit()
+        return key
+
+
+async def _clear_pool() -> None:
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.type == ApiKeyType.pool))
+        await db.commit()
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_pool():
+    await _clear_pool()
+    yield
+    await _clear_pool()
+
+
+async def test_ensure_pool_creates_up_to_size(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setattr(config, "POOL_SIZE", 3)
+    await ApiKeyPoolService.ensure_pool()
+    assert await _pool_count() == 3
+
+
+async def test_ensure_pool_is_idempotent_when_full(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setattr(config, "POOL_SIZE", 3)
+    await ApiKeyPoolService.ensure_pool()
+    await ApiKeyPoolService.ensure_pool()
+    assert await _pool_count() == 3
+
+
+async def test_ensure_pool_tops_up_partial_pool(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setattr(config, "POOL_SIZE", 4)
+    await _add_pool_key(age_seconds=120)
+    await ApiKeyPoolService.ensure_pool()
+    assert await _pool_count() == 4

--- a/tests/test_api_key_pool.py
+++ b/tests/test_api_key_pool.py
@@ -83,7 +83,6 @@ async def test_ensure_pool_tops_up_partial_pool(monkeypatch):
 
 async def test_claim_returns_warm_row_and_resets_metadata():
     warm = await _add_pool_key(age_seconds=120)
-    user_id = uuid.uuid4()
     async with AsyncSessionLocal() as db:
         # Need a real user row for the FK; create a throwaway user.
         from src.models.user import User

--- a/tests/test_api_key_pool.py
+++ b/tests/test_api_key_pool.py
@@ -79,3 +79,81 @@ async def test_ensure_pool_tops_up_partial_pool(monkeypatch):
     await _add_pool_key(age_seconds=120)
     await ApiKeyPoolService.ensure_pool()
     assert await _pool_count() == 4
+
+
+async def test_claim_returns_warm_row_and_resets_metadata():
+    warm = await _add_pool_key(age_seconds=120)
+    user_id = uuid.uuid4()
+    async with AsyncSessionLocal() as db:
+        # Need a real user row for the FK; create a throwaway user.
+        from src.models.user import User
+
+        user = User(email=f"pool-{uuid.uuid4().hex}@example.com", email_verified=True)
+        db.add(user)
+        await db.flush()
+        row = await ApiKeyPoolService.claim_warm_key(
+            db, target_type=ApiKeyType.api, user_id=user.id, name="my-key", monthly_limit=12.5
+        )
+        await db.commit()
+        assert row is not None
+        assert row.key == warm  # same already-propagated string
+        assert row.type == ApiKeyType.api
+        assert row.user_id == user.id
+        assert row.name == "my-key"
+        assert row.monthly_limit == 12.5
+        assert (datetime.now() - row.created_at) < timedelta(seconds=30)
+        # cleanup the claimed key + user
+        await db.delete(row)
+        await db.delete(user)
+        await db.commit()
+
+
+async def test_claim_returns_none_when_no_ready_pool_key():
+    # Fresh pool key (age 0) is younger than the warm threshold -> not claimable.
+    await _add_pool_key(age_seconds=0)
+    async with AsyncSessionLocal() as db:
+        row = await ApiKeyPoolService.claim_warm_key(
+            db, target_type=ApiKeyType.api, user_id=uuid.uuid4(), name="x"
+        )
+        await db.rollback()
+        assert row is None
+
+
+async def test_claim_returns_none_when_pool_empty():
+    async with AsyncSessionLocal() as db:
+        row = await ApiKeyPoolService.claim_warm_key(
+            db, target_type=ApiKeyType.api, user_id=uuid.uuid4(), name="x"
+        )
+        await db.rollback()
+        assert row is None
+
+
+async def test_concurrent_claims_get_distinct_rows():
+    from src.models.user import User
+
+    warm_keys = {await _add_pool_key(age_seconds=120), await _add_pool_key(age_seconds=120)}
+    async with AsyncSessionLocal() as db:
+        user = User(email=f"pool-{uuid.uuid4().hex}@example.com", email_verified=True)
+        db.add(user)
+        await db.commit()
+        user_id = user.id
+
+    async def _claim_one(name: str) -> str | None:
+        async with AsyncSessionLocal() as db:
+            row = await ApiKeyPoolService.claim_warm_key(
+                db, target_type=ApiKeyType.api, user_id=user_id, name=name
+            )
+            await db.commit()
+            return row.key if row else None
+
+    results = await asyncio.gather(_claim_one("a"), _claim_one("b"))
+    assert None not in results
+    assert set(results) == warm_keys  # two distinct warm rows, no double-claim
+
+    # cleanup the two claimed keys + user
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.user_id == user_id))
+        from src.models.user import User as U
+
+        await db.execute(delete(U).where(U.id == user_id))
+        await db.commit()

--- a/tests/test_api_key_pool.py
+++ b/tests/test_api_key_pool.py
@@ -157,3 +157,30 @@ async def test_concurrent_claims_get_distinct_rows():
 
         await db.execute(delete(U).where(U.id == user_id))
         await db.commit()
+
+
+async def test_claim_warm_string_returns_key_and_removes_pool_row():
+    warm = await _add_pool_key(age_seconds=120)
+    async with AsyncSessionLocal() as db:
+        s = await ApiKeyPoolService.claim_warm_string(db)
+        await db.commit()
+        assert s == warm
+    # the pool row is gone (consumed), so the pool is now empty
+    assert await _pool_count() == 0
+
+
+async def test_claim_warm_string_returns_none_when_no_ready_key():
+    await _add_pool_key(age_seconds=0)  # too fresh
+    async with AsyncSessionLocal() as db:
+        s = await ApiKeyPoolService.claim_warm_string(db)
+        await db.rollback()
+        assert s is None
+
+
+async def test_schedule_refill_tops_up(monkeypatch):
+    from src.config import config
+
+    monkeypatch.setattr(config, "POOL_SIZE", 2)
+    task = ApiKeyPoolService.schedule_refill()
+    await task
+    assert await _pool_count() == 2

--- a/tests/test_warm_key_claim_integration.py
+++ b/tests/test_warm_key_claim_integration.py
@@ -1,0 +1,88 @@
+"""Each new-string creation path hands out a pre-warmed pool key when one is ready.
+
+Services open their own AsyncSessionLocal and commit to the test DB, so these tests
+clear the pool and clean up created rows themselves.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import delete
+
+from src.interfaces.api_keys import ApiKeyType
+from src.models.api_key import ApiKey as ApiKeyDB
+from src.models.base import AsyncSessionLocal
+from src.models.user import User
+from src.services.api_key import ApiKeyService
+from src.services.api_key_pool import POOL_SENTINEL_NAME
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _add_warm_pool_key() -> str:
+    async with AsyncSessionLocal() as db:
+        key = ApiKeyDB.generate_key()
+        row = ApiKeyDB(key=key, name=POOL_SENTINEL_NAME, type=ApiKeyType.pool)
+        row.created_at = datetime.now() - timedelta(seconds=120)
+        db.add(row)
+        await db.commit()
+        return key
+
+
+async def _clear_pool() -> None:
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.type == ApiKeyType.pool))
+        await db.commit()
+
+
+async def _make_user() -> uuid.UUID:
+    async with AsyncSessionLocal() as db:
+        user = User(email=f"warm-{uuid.uuid4().hex}@example.com", email_verified=True)
+        db.add(user)
+        await db.commit()
+        return user.id
+
+
+async def _cleanup_user(user_id: uuid.UUID) -> None:
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.user_id == user_id))
+        await db.execute(delete(User).where(User.id == user_id))
+        await db.commit()
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_pool():
+    await _clear_pool()
+    yield
+    await _clear_pool()
+
+
+async def test_create_api_key_uses_warm_pool_key(monkeypatch):
+    # Stop the post-claim background refill from racing this test's pool assertions.
+    from src.services import api_key_pool
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    warm = await _add_warm_pool_key()
+    user_id = await _make_user()
+    try:
+        result = await ApiKeyService.create_api_key(user_id=user_id, name="warm-test")
+        assert result.full_key == warm  # got the pre-warmed string, not a cold one
+        assert result.type == ApiKeyType.api
+    finally:
+        await _cleanup_user(user_id)
+
+
+async def test_create_api_key_falls_back_to_cold_when_pool_empty(monkeypatch):
+    from src.services import api_key_pool
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    user_id = await _make_user()
+    try:
+        result = await ApiKeyService.create_api_key(user_id=user_id, name="cold-test")
+        assert len(result.full_key) == 32  # a freshly generated hex key
+        assert result.type == ApiKeyType.api
+    finally:
+        await _cleanup_user(user_id)

--- a/tests/test_warm_key_claim_integration.py
+++ b/tests/test_warm_key_claim_integration.py
@@ -86,3 +86,55 @@ async def test_create_api_key_falls_back_to_cold_when_pool_empty(monkeypatch):
         assert result.type == ApiKeyType.api
     finally:
         await _cleanup_user(user_id)
+
+
+async def test_cli_create_uses_warm_pool_key(monkeypatch):
+    from src.services import api_key_pool
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    warm = await _add_warm_pool_key()
+    user_id = await _make_user()
+    try:
+        result = await ApiKeyService.rotate_or_create_cli_api_key(user_id=user_id, host="laptop")
+        assert result.full_key == warm
+        assert result.type == ApiKeyType.cli
+        assert result.expires_at is not None
+    finally:
+        await _cleanup_user(user_id)
+
+
+async def test_cli_rotate_adopts_warm_string_in_place(monkeypatch):
+    from src.services import api_key_pool
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    user_id = await _make_user()
+    try:
+        # First mint with an empty pool -> cold key on a brand-new row.
+        first = await ApiKeyService.rotate_or_create_cli_api_key(user_id=user_id, host="laptop")
+        original_id = first.id
+
+        # Now a warm key is ready; rotating must adopt the warm string into the SAME row.
+        warm = await _add_warm_pool_key()
+        second = await ApiKeyService.rotate_or_create_cli_api_key(user_id=user_id, host="laptop")
+        assert second.id == original_id  # same row -> usage history preserved
+        assert second.full_key == warm  # adopted the warm, already-propagated string
+        # the consumed pool row is gone
+        assert await _pool_count_cli_helper() == 0
+    finally:
+        await _cleanup_user(user_id)
+
+
+async def _pool_count_cli_helper() -> int:
+    from sqlalchemy import func, select
+
+    async with AsyncSessionLocal() as db:
+        return int(
+            (
+                await db.execute(
+                    select(func.count()).select_from(ApiKeyDB).where(ApiKeyDB.type == ApiKeyType.pool)
+                )
+            ).scalar()
+            or 0
+        )

--- a/tests/test_warm_key_claim_integration.py
+++ b/tests/test_warm_key_claim_integration.py
@@ -126,6 +126,40 @@ async def test_cli_rotate_adopts_warm_string_in_place(monkeypatch):
         await _cleanup_user(user_id)
 
 
+async def test_chat_create_uses_warm_pool_key(monkeypatch):
+    from src.services import api_key_pool
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    warm = await _add_warm_pool_key()
+    user_id = await _make_user()
+    try:
+        result = await ApiKeyService.get_or_create_chat_api_key(user_id=user_id)
+        assert result.full_key == warm
+        assert result.type == ApiKeyType.chat
+    finally:
+        await _cleanup_user(user_id)
+
+
+async def test_chat_get_existing_does_not_consume_pool(monkeypatch):
+    from src.services import api_key_pool
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    # First create (empty pool -> cold), then add a warm key and fetch again:
+    # the second call must return the EXISTING chat key, not consume the pool.
+    user_id = await _make_user()
+    try:
+        first = await ApiKeyService.get_or_create_chat_api_key(user_id=user_id)
+        warm = await _add_warm_pool_key()
+        second = await ApiKeyService.get_or_create_chat_api_key(user_id=user_id)
+        assert second.full_key == first.full_key  # existing key returned
+        assert second.full_key != warm
+        assert await _pool_count_cli_helper() == 1  # pool untouched
+    finally:
+        await _cleanup_user(user_id)
+
+
 async def _pool_count_cli_helper() -> int:
     from sqlalchemy import func, select
 

--- a/tests/test_warm_key_claim_integration.py
+++ b/tests/test_warm_key_claim_integration.py
@@ -160,6 +160,32 @@ async def test_chat_get_existing_does_not_consume_pool(monkeypatch):
         await _cleanup_user(user_id)
 
 
+async def test_liberclaw_create_uses_warm_pool_key(monkeypatch):
+    from src.services import api_key_pool
+    from src.services.liberclaw import LiberclawService
+    from src.models.liberclaw_user import LiberclawUser
+
+    monkeypatch.setattr(api_key_pool.ApiKeyPoolService, "schedule_refill", staticmethod(lambda: None))
+
+    warm = await _add_warm_pool_key()
+    user_id = f"lc-{uuid.uuid4().hex}"
+    try:
+        result = await LiberclawService.get_or_create_api_key(user_id=user_id, user_type="discord")
+        assert result.is_new is True
+        assert result.key == warm  # warm, already-propagated string
+    finally:
+        async with AsyncSessionLocal() as db:
+            lc = (
+                await db.execute(
+                    __import__("sqlalchemy").select(LiberclawUser).where(LiberclawUser.user_id == user_id)
+                )
+            ).scalars().first()
+            if lc is not None:
+                await db.execute(delete(ApiKeyDB).where(ApiKeyDB.liberclaw_user_id == lc.id))
+                await db.execute(delete(LiberclawUser).where(LiberclawUser.id == lc.id))
+                await db.commit()
+
+
 async def _pool_count_cli_helper() -> int:
     from sqlalchemy import func, select
 


### PR DESCRIPTION
## Summary
- New keys take ~30s to propagate to inference instances (which pull the `GET /api-keys/admin/list` whitelist), so a freshly created key 401s during that window. This adds a pool of pre-created, already-propagated keys so a "new" key is recognized immediately.
- Pool keys are real `api_keys` rows (`type='pool'`, `user_id=NULL`, sentinel `name='__pool__'`) that ride in the admin whitelist via the existing fall-through, so they warm up ahead of time. New `ApiKeyPoolService` (`src/services/api_key_pool.py`): `ensure_pool` (idempotent top-up to `POOL_SIZE`, lock-serialized), `claim_warm_key` (atomic `SELECT … FOR UPDATE SKIP LOCKED`, only claims rows older than `POOL_WARM_THRESHOLD_SECONDS` so they've actually propagated; resets all identity fields incl. `is_active`/`deleted_at`), `claim_warm_string` (for CLI rotate), `schedule_refill` (fire-and-forget background top-up).
- Wired into all four creation paths: `POST /api-keys`, `POST /api-keys/cli` (create + rotate-in-place, preserving usage history), `GET /api-keys/chat` (first-time create), `POST /liberclaw/api-key` (create). Each falls back to cold key generation when no warm key is ready — never errors, degrades to today's behavior.
- Pool seeded at startup + periodically reconciled (`src/utils/cron.py` lifespan). Config: `POOL_SIZE=5`, `POOL_WARM_THRESHOLD_SECONDS=60`, `POOL_RECONCILE_INTERVAL_SECONDS=300`. New `pool` value added to `ApiKeyType` enum (Alembic migration `c1d2e3f4a5b6`).
- Unclaimed pool keys are never billed (`register_inference_call` computes a `None` chargeable user for ownerless keys) and never appear in user-facing listings.

## Test Plan
- [x] `poetry run pytest` — 106 passed (new: pool service unit tests incl. concurrency/warmth/fallback, integration tests for all 4 paths, whitelist-inclusion lock; all pre-existing tests green incl. CLI in-place rotation)
- [x] `poetry run ruff check src tests` — clean
- [x] `poetry run mypy` on touched modules — clean
- [ ] After deploy: run the migration (`alembic upgrade head`) to add the `pool` enum value; verify the pool seeds at startup and a freshly created key works immediately (no 401 window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)