### PR TITLE
Bill cached (prefix-cache) input tokens correctly

### DIFF
--- a/src/interfaces/aleph.py
+++ b/src/interfaces/aleph.py
@@ -12,6 +12,9 @@ class TextCapability(BaseModel):
 class TextPricing(BaseModel):
     price_per_million_input_tokens: float
     price_per_million_output_tokens: float
+    # Dedicated rate for input tokens served from the prefix cache. When unset, cached
+    # input tokens fall back to the full input rate (no discount).
+    price_per_million_cached_input_tokens: float | None = None
 
 
 class EmbeddingCapability(BaseModel):

--- a/src/routes/api_keys/api_keys.py
+++ b/src/routes/api_keys/api_keys.py
@@ -216,7 +216,8 @@ async def register_inference_call(usage_log: InferenceCallData) -> None:
                     credits_used = await aleph_service.calculate_price(
                         model_id=usage_log.model_name,
                         input_tokens=usage_log.input_tokens,
-                        output_tokens=usage_log.output_tokens - usage_log.cached_tokens,
+                        output_tokens=usage_log.output_tokens,
+                        cached_tokens=usage_log.cached_tokens,
                     )
                     success = await ApiKeyService.register_inference_call(
                         key=usage_log.key,
@@ -246,7 +247,8 @@ async def register_inference_call(usage_log: InferenceCallData) -> None:
                     actual_cost = await aleph_service.calculate_price(
                         model_id=usage_log.model_name,
                         input_tokens=usage_log.input_tokens,
-                        output_tokens=usage_log.output_tokens - usage_log.cached_tokens,
+                        output_tokens=usage_log.output_tokens,
+                        cached_tokens=usage_log.cached_tokens,
                     )
                     await ApiKeyService.register_inference_call(
                         key=usage_log.key,
@@ -282,7 +284,8 @@ async def register_inference_call(usage_log: InferenceCallData) -> None:
                     credits_used = await aleph_service.calculate_price(
                         model_id=usage_log.model_name,
                         input_tokens=usage_log.input_tokens,
-                        output_tokens=usage_log.output_tokens - usage_log.cached_tokens,
+                        output_tokens=usage_log.output_tokens,
+                        cached_tokens=usage_log.cached_tokens,
                     )
                     logger.debug(f"Calculated {credits_used} credits for text model {usage_log.model_name}")
 

--- a/src/services/aleph.py
+++ b/src/services/aleph.py
@@ -64,7 +64,7 @@ class AlephService:
         return None
 
     async def calculate_price(
-        self, model_id: str, input_tokens: int = 0, output_tokens: int = 0, image_count: int = 0
+        self, model_id: str, input_tokens: int = 0, output_tokens: int = 0, cached_tokens: int = 0, image_count: int = 0
     ) -> float:
         """
         Calculate the price for a given model
@@ -73,6 +73,8 @@ class AlephService:
             model_id: The ID of the model to use
             input_tokens: Number of input tokens (for text models)
             output_tokens: Number of output tokens (for text models)
+            cached_tokens: Number of input tokens served from the prefix cache (subset of
+                input_tokens), billed at the model's cached rate when defined
             image_count: Number of images (for image models)
 
         Returns:
@@ -94,7 +96,17 @@ class AlephService:
             pricing = model.pricing["text"]
             if not isinstance(pricing, TextPricing):
                 raise ValueError(f"Invalid text pricing format for model: {model_id}")
-            input_price = input_tokens / 1_000_000 * pricing.price_per_million_input_tokens
+            # Prefix-cache hits are a subset of the input tokens; bill them at the dedicated
+            # cached rate when defined, otherwise at the full input rate (no discount).
+            # Clamp to guard against malformed reports where cached > input.
+            cached = max(0, min(cached_tokens, input_tokens))
+            cached_rate = (
+                pricing.price_per_million_cached_input_tokens
+                if pricing.price_per_million_cached_input_tokens is not None
+                else pricing.price_per_million_input_tokens
+            )
+            input_price = (input_tokens - cached) / 1_000_000 * pricing.price_per_million_input_tokens
+            input_price += cached / 1_000_000 * cached_rate
             output_price = output_tokens / 1_000_000 * pricing.price_per_million_output_tokens
             total_price = input_price + output_price
 

--- a/tests/test_text_cached_pricing.py
+++ b/tests/test_text_cached_pricing.py
@@ -1,0 +1,83 @@
+import pytest
+
+from src.interfaces.aleph import ModelInfo, TextCapability, TextPricing
+from src.services.aleph import aleph_service
+
+
+def _make_model(monkeypatch, cached_rate):
+    model = ModelInfo(
+        id="glm",
+        name="GLM",
+        capabilities={"text": TextCapability(context_window=1000, function_calling=True, reasoning=True)},
+        pricing={
+            "text": TextPricing(
+                price_per_million_input_tokens=10.0,
+                price_per_million_output_tokens=30.0,
+                price_per_million_cached_input_tokens=cached_rate,
+            )
+        },
+    )
+
+    async def fake_get_model_info(model_id: str):
+        return model if model_id == "glm" else None
+
+    monkeypatch.setattr(aleph_service, "get_model_info", fake_get_model_info)
+    return model
+
+
+@pytest.fixture
+def model_with_cached_rate(monkeypatch):
+    return _make_model(monkeypatch, cached_rate=1.0)
+
+
+@pytest.fixture
+def model_without_cached_rate(monkeypatch):
+    return _make_model(monkeypatch, cached_rate=None)
+
+
+@pytest.mark.asyncio
+async def test_no_cached_tokens_unchanged(model_with_cached_rate):
+    # 1M input + 1M output, no cache: 10 + 30
+    price = await aleph_service.calculate_price(
+        model_id="glm", input_tokens=1_000_000, output_tokens=1_000_000, cached_tokens=0
+    )
+    assert price == 40.0
+
+
+@pytest.mark.asyncio
+async def test_cached_tokens_billed_at_cached_rate(model_with_cached_rate):
+    # 600k full-rate input + 400k cached input + 0 output: 6.0 + 0.4
+    price = await aleph_service.calculate_price(
+        model_id="glm", input_tokens=1_000_000, output_tokens=0, cached_tokens=400_000
+    )
+    assert price == round(600_000 / 1_000_000 * 10.0 + 400_000 / 1_000_000 * 1.0, 5)
+    assert price == 6.4
+
+
+@pytest.mark.asyncio
+async def test_cached_does_not_touch_output(model_with_cached_rate):
+    # cached must reduce input, never output
+    price = await aleph_service.calculate_price(
+        model_id="glm", input_tokens=1_000_000, output_tokens=1_000_000, cached_tokens=1_000_000
+    )
+    # all input cached (1.0) + full output (30.0)
+    assert price == round(1.0 + 30.0, 5)
+
+
+@pytest.mark.asyncio
+async def test_no_cached_rate_falls_back_to_input_rate(model_without_cached_rate):
+    # cached rate unset -> cached billed at full input rate -> no discount
+    price = await aleph_service.calculate_price(
+        model_id="glm", input_tokens=1_000_000, output_tokens=0, cached_tokens=500_000
+    )
+    assert price == 10.0
+
+
+@pytest.mark.asyncio
+async def test_cached_clamped_to_input(model_with_cached_rate):
+    # cached > input must not produce negative full-rate input
+    price = await aleph_service.calculate_price(
+        model_id="glm", input_tokens=100, output_tokens=0, cached_tokens=1000
+    )
+    # clamped to 100 cached tokens at cached rate 1.0
+    assert price == round(100 / 1_000_000 * 1.0, 5)


### PR DESCRIPTION
## What

vLLM reports prefix-cache hits as `usage.prompt_tokens_details.cached_tokens` (a subset of `prompt_tokens`). This wires that into billing.

## Why

The usage route billed `output_tokens - cached_tokens`, which is wrong: cached tokens are cached **input** tokens, not output. With real cached counts this would mis-bill (and could go negative).

## Changes

- `TextPricing`: add optional `price_per_million_cached_input_tokens`.
- `calculate_price`: `cached_tokens` (clamped to `input_tokens`) are deducted from full-rate input and billed at the cached rate; falls back to the full input rate when unset. Output untouched.
- Usage route: pass real `output_tokens` + `cached_tokens` to `calculate_price` (all 3 call sites).
- Tests for cached pricing.

## Notes

- No behavior change while `cached_tokens` is 0 (today's case).
- Needs `price_per_million_cached_input_tokens` in the pricing aggregate to actually discount; otherwise cached tokens bill at the normal input rate.