### PR TITLE
perf(api-keys): index inference_calls + batch liberclaw usage in admin/list

### DIFF
--- a/alembic/versions/d4e5f6a7b8c9_index_inference_calls_api_key_id_used_at.py
+++ b/alembic/versions/d4e5f6a7b8c9_index_inference_calls_api_key_id_used_at.py
@@ -1,0 +1,46 @@
+"""index inference_calls (api_key_id, used_at)
+
+Revision ID: d4e5f6a7b8c9
+Revises: c1d2e3f4a5b6
+Create Date: 2026-06-19
+
+inference_calls had only its PK index. The admin key-list gate and the monthly/
+liberclaw usage rollups all run SUM(credits_used) WHERE api_key_id = ? AND
+used_at >= ?, which seq-scanned the whole (multi-million row) table each time.
+Add a composite index so those become index range scans. Created CONCURRENTLY to
+avoid locking writes on the large table.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEX_NAME = "ix_inference_calls_api_key_id_used_at"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            INDEX_NAME,
+            "inference_calls",
+            ["api_key_id", "used_at"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="inference_calls",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/src/models/inference_call.py
+++ b/src/models/inference_call.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     CheckConstraint,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
 )
@@ -34,8 +35,12 @@ class InferenceCall(Base):
 
     api_key: Mapped["ApiKey"] = relationship("ApiKey", back_populates="usages")
 
-    # Enforce non-negative credits usage
-    __table_args__ = (CheckConstraint("credits_used >= 0", name="check_credits_used_non_negative"),)
+    # Enforce non-negative credits usage; index the usage-rollup access path
+    # (SUM(credits_used) WHERE api_key_id = ? AND used_at >= ?).
+    __table_args__ = (
+        CheckConstraint("credits_used >= 0", name="check_credits_used_non_negative"),
+        Index("ix_inference_calls_api_key_id_used_at", "api_key_id", "used_at"),
+    )
 
     def __init__(
         self,

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -624,6 +624,38 @@ class ApiKeyService:
                     ).all()
                     monthly_usage = {row[0]: float(row[1]) for row in usage_rows}
 
+                # Pre-fetch liberclaw rolling-window usage, grouped per distinct window, to avoid
+                # an N+1 SUM over inference_calls for every liberclaw key.
+                liberclaw_keys = [
+                    k
+                    for k in api_keys
+                    if k.type == ApiKeyType.liberclaw and k.liberclaw_user_id and k.liberclaw_user
+                ]
+                liberclaw_usage: dict[uuid.UUID, float] = {}
+                if liberclaw_keys:
+                    now = datetime.now()
+                    key_ids_by_window: dict[int, list[uuid.UUID]] = {}
+                    for k in liberclaw_keys:
+                        tier_config = LIBERCLAW_TIERS.get(k.liberclaw_user.tier, LIBERCLAW_TIERS["free"])
+                        key_ids_by_window.setdefault(tier_config["rolling_window_days"], []).append(k.id)
+                    for window_days, key_ids in key_ids_by_window.items():
+                        cutoff = now - timedelta(days=window_days)
+                        rows = (
+                            await db.execute(
+                                select(
+                                    InferenceCall.api_key_id,
+                                    sql_func.coalesce(sql_func.sum(InferenceCall.credits_used), 0.0),
+                                )
+                                .where(
+                                    InferenceCall.api_key_id.in_(key_ids),
+                                    InferenceCall.used_at >= cutoff,
+                                )
+                                .group_by(InferenceCall.api_key_id)
+                            )
+                        ).all()
+                        for row in rows:
+                            liberclaw_usage[row[0]] = float(row[1])
+
                 # Filter keys with sufficient credits available
                 expiry_now = datetime.now()
                 result = []
@@ -632,24 +664,14 @@ class ApiKeyService:
                     if key.expires_at is not None and key.expires_at < expiry_now:
                         continue
                     if key.type == ApiKeyType.liberclaw:
-                        # Check rolling window usage against tier limit
+                        # Rolling-window usage vs tier limit (usage pre-fetched above).
                         if key.liberclaw_user_id is None:
                             continue
                         lc_user = key.liberclaw_user
                         if lc_user is None:
                             continue
                         tier_config = LIBERCLAW_TIERS.get(lc_user.tier, LIBERCLAW_TIERS["free"])
-                        cutoff = datetime.now() - timedelta(days=tier_config["rolling_window_days"])
-                        usage = float(
-                            (
-                                await db.execute(
-                                    select(sql_func.coalesce(sql_func.sum(InferenceCall.credits_used), 0.0)).where(
-                                        InferenceCall.api_key_id == key.id, InferenceCall.used_at >= cutoff
-                                    )
-                                )
-                            ).scalar()
-                            or 0.0
-                        )
+                        usage = liberclaw_usage.get(key.id, 0.0)
                         if usage >= tier_config["credits_limit"]:
                             continue
                     elif key.type in chargeable_api_types:

--- a/tests/test_admin_list_enforcement.py
+++ b/tests/test_admin_list_enforcement.py
@@ -11,11 +11,13 @@ import pytest
 
 from src.interfaces.api_keys import ApiKeyType
 from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.liberclaw_tiers import LIBERCLAW_TIERS
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.credit_transaction import CreditTransaction
 from src.models.entitlement_window import EntitlementWindow
 from src.models.inference_call import InferenceCall
+from src.models.liberclaw_user import LiberclawUser
 from src.models.plan_subscription import PlanSubscription
 from src.models.user import User
 from src.services.api_key import ApiKeyService
@@ -172,6 +174,67 @@ async def test_pool_keys_are_included_in_whitelist_unconditionally():
 
             await db.execute(delete(ApiKeyDB).where(ApiKeyDB.key == pool_key))
             await db.commit()
+
+
+async def _setup_liberclaw(*, tier="free", usage=None, used_days_ago=1):
+    """Create a liberclaw user + liberclaw key with optional usage at ``used_days_ago``.
+
+    Returns (liberclaw_user_id, key_str).
+    """
+    now = datetime.now()
+    async with AsyncSessionLocal() as db:
+        lc = LiberclawUser(user_id=uuid.uuid4().hex, user_type="discord", tier=tier)
+        db.add(lc)
+        await db.flush()
+        key = ApiKeyDB(
+            key=ApiKeyDB.generate_key(), name=uuid.uuid4().hex, type=ApiKeyType.liberclaw, liberclaw_user_id=lc.id
+        )
+        db.add(key)
+        await db.flush()
+        if usage:
+            call = InferenceCall(api_key_id=key.id, credits_used=usage, model_name="m")
+            call.used_at = now - timedelta(days=used_days_ago)
+            db.add(call)
+        await db.commit()
+        return lc.id, key.key
+
+
+async def _cleanup_liberclaw(lc_id):
+    async with AsyncSessionLocal() as db:
+        from sqlalchemy import delete
+
+        # inference_calls cascade via api_keys FK; delete keys then the liberclaw user.
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.liberclaw_user_id == lc_id))
+        await db.execute(delete(LiberclawUser).where(LiberclawUser.id == lc_id))
+        await db.commit()
+
+
+async def test_liberclaw_key_included_within_tier_limit():
+    limit = LIBERCLAW_TIERS["free"]["credits_limit"]
+    lc_id, key = await _setup_liberclaw(usage=limit / 2)  # half the rolling-window allowance
+    try:
+        assert key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup_liberclaw(lc_id)
+
+
+async def test_liberclaw_key_excluded_over_tier_limit():
+    limit = LIBERCLAW_TIERS["free"]["credits_limit"]
+    lc_id, key = await _setup_liberclaw(usage=limit + 1)  # exhausted the rolling window
+    try:
+        assert key not in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup_liberclaw(lc_id)
+
+
+async def test_liberclaw_usage_outside_window_ignored():
+    """Usage older than the tier's rolling window must not count (validates the prefetch cutoff)."""
+    free = LIBERCLAW_TIERS["free"]
+    lc_id, key = await _setup_liberclaw(usage=free["credits_limit"] + 1, used_days_ago=free["rolling_window_days"] + 5)
+    try:
+        assert key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup_liberclaw(lc_id)
 
 
 async def _balance(user_id) -> float:


### PR DESCRIPTION
## Problem

The gateway (`libertai-api`) whitelists API keys by fetching `GET /api-keys/admin/list` and pushing the result to the model instances. That endpoint (`ApiKeyService.get_admin_all_api_keys`) ran an **N+1 `SUM(credits_used)` over `inference_calls` for every active liberclaw key** — and `inference_calls` (2.2M rows on prod) had **no index on `api_key_id`/`used_at`**, so each was a full parallel seq scan (~62ms × 439 keys ≈ **~30s**, growing).

That crosses the gateway's account-fetch timeout → `Exception fetching accounts` (`httpx.ReadTimeout`) → the refresh is dropped → **newly-credited keys never propagate to the model instances**, so users get `403` despite a valid balance.

Measured on prod: the per-key N+1 ≈ 30s; the equivalent batched query = **489ms**; with the index, sub-ms.

## Changes

- **Migration `d4e5f6a7b8c9`**: composite index `inference_calls(api_key_id, used_at)`, created `CONCURRENTLY` (non-blocking on the large table). Also speeds the monthly-usage rollup.
- Same index declared on the `InferenceCall` model (`__table_args__`).
- **Batch the liberclaw rolling-window usage** into one grouped query per distinct window instead of one `SUM` per key. All liberclaw tiers currently share a 30-day window, but the code groups by window so it stays correct if that changes.
- 3 regression tests for liberclaw whitelist gating (within limit, over limit, usage outside the window).

## Verification

- `37 passed` across the api-key test suite (incl. the 3 new liberclaw cases).
- ruff clean, `py_compile` OK, alembic single head off `main`'s `c1d2e3f4a5b6`.

## Related

Paired with `libertai-api` `main` commit bumping the `get_active_keys` fetch timeout 30s→120s (stopgap so a slow cycle isn't dropped). This PR removes the slowness at the source.