### PR TITLE
feat: Teams v1 — team balance, seat subscriptions, extra credits

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -20,6 +20,11 @@ from src.models.oauth_connection import OAuthConnection  # noqa
 from src.models.plan_subscription import PlanSubscription  # noqa
 from src.models.plan_subscription_event import PlanSubscriptionEvent  # noqa
 from src.models.session import Session  # noqa
+from src.models.team import Team  # noqa
+from src.models.team_credit_transaction import TeamCreditTransaction  # noqa
+from src.models.team_invite import TeamInvite  # noqa
+from src.models.team_ledger_entry import TeamLedgerEntry  # noqa
+from src.models.team_membership import TeamMembership  # noqa
 from src.models.user import User  # noqa
 from src.models.wallet_challenge import WalletChallenge  # noqa
 from src.models.wallet_connection import WalletConnection  # noqa

--- a/alembic/versions/0b8ab94fc7d8_teams_v1.py
+++ b/alembic/versions/0b8ab94fc7d8_teams_v1.py
@@ -96,16 +96,25 @@ def upgrade() -> None:
         "inference_calls",
         sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="SET NULL"), nullable=True),
     )
-    op.create_index(
-        "ix_inference_calls_team_id_used_at",
-        "inference_calls",
-        ["team_id", "used_at"],
-        postgresql_where=sa.text("team_id IS NOT NULL"),
-    )
+    # inference_calls is the hottest table — build this index CONCURRENTLY (outside the
+    # migration's transaction) so it never takes a write-blocking lock in production.
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_inference_calls_team_id_used_at",
+            "inference_calls",
+            ["team_id", "used_at"],
+            postgresql_where=sa.text("team_id IS NOT NULL"),
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_inference_calls_team_id_used_at", table_name="inference_calls")
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_inference_calls_team_id_used_at",
+            table_name="inference_calls",
+            postgresql_concurrently=True,
+        )
     op.drop_column("inference_calls", "team_id")
     op.drop_column("plan_subscriptions", "seat_price_snapshot")
     op.drop_column("plan_subscriptions", "team_id")

--- a/alembic/versions/0b8ab94fc7d8_teams_v1.py
+++ b/alembic/versions/0b8ab94fc7d8_teams_v1.py
@@ -1,0 +1,116 @@
+"""Teams v1: teams, memberships, invites, team balance, ledger; seat + team_id columns.
+
+Revision ID: 0b8ab94fc7d8
+Revises: c4f1a9d2e7b8
+Create Date: 2026-07-04
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0b8ab94fc7d8"
+down_revision: Union[str, None] = "c4f1a9d2e7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="active"),
+        sa.Column("seat_prices", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("extra_credits_monthly_cap", sa.Float(), nullable=True),
+        sa.Column("extra_credits_member_default_cap", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_table(
+        "team_memberships",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True),
+        sa.Column("role", sa.String(), nullable=False, server_default="member"),
+        sa.Column("extra_credits_cap_override", sa.Float(), nullable=True),
+        sa.Column("invited_by", sa.UUID(), nullable=True),
+        sa.Column("joined_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_index("ix_team_memberships_team_id", "team_memberships", ["team_id"])
+    op.create_table(
+        "team_invites",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False, unique=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("expires_at", sa.TIMESTAMP(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_table(
+        "team_credit_transactions",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("external_reference", sa.String(), nullable=True, unique=True),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("amount_left", sa.Float(), nullable=False),
+        sa.Column(
+            "provider",
+            postgresql.ENUM(name="credittransactionprovider", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            postgresql.ENUM(name="credittransactionstatus", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("amount >= 0", name="check_team_tx_amount_non_negative"),
+        sa.CheckConstraint("amount_left >= 0", name="check_team_tx_amount_left_non_negative"),
+        sa.CheckConstraint("amount_left <= amount", name="check_team_tx_amount_left_not_exceeding"),
+    )
+    op.create_index("ix_team_credit_transactions_team_id", "team_credit_transactions", ["team_id"])
+    op.create_table(
+        "team_ledger_entries",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("entry_type", sa.String(), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("metadata_json", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("amount >= 0", name="check_ledger_amount_non_negative"),
+    )
+    op.create_index("ix_team_ledger_entries_team_id", "team_ledger_entries", ["team_id"])
+
+    op.add_column(
+        "plan_subscriptions",
+        sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="SET NULL"), nullable=True),
+    )
+    op.add_column("plan_subscriptions", sa.Column("seat_price_snapshot", sa.Float(), nullable=True))
+    op.add_column(
+        "inference_calls",
+        sa.Column("team_id", sa.UUID(), sa.ForeignKey("teams.id", ondelete="SET NULL"), nullable=True),
+    )
+    op.create_index(
+        "ix_inference_calls_team_id_used_at",
+        "inference_calls",
+        ["team_id", "used_at"],
+        postgresql_where=sa.text("team_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_inference_calls_team_id_used_at", table_name="inference_calls")
+    op.drop_column("inference_calls", "team_id")
+    op.drop_column("plan_subscriptions", "seat_price_snapshot")
+    op.drop_column("plan_subscriptions", "team_id")
+    op.drop_table("team_ledger_entries")
+    op.drop_table("team_credit_transactions")
+    op.drop_table("team_invites")
+    op.drop_table("team_memberships")
+    op.drop_table("teams")

--- a/src/interfaces/payments.py
+++ b/src/interfaces/payments.py
@@ -84,6 +84,7 @@ class SubscriptionResponse(BaseModel):
     cancel_at_period_end: bool = False
     pending_tier: str | None = None
     is_trial: bool = False
+    is_team_seat: bool = False
     # Live gateway decision for the next call: lets the UI show the paywall directly.
     allowed: bool = True
     source: str = "tier"  # "tier" | "prepaid" | "blocked"

--- a/src/interfaces/payments.py
+++ b/src/interfaces/payments.py
@@ -85,6 +85,7 @@ class SubscriptionResponse(BaseModel):
     pending_tier: str | None = None
     is_trial: bool = False
     is_team_seat: bool = False
+    team_name: str | None = None
     # Live gateway decision for the next call: lets the UI show the paywall directly.
     allowed: bool = True
     source: str = "tier"  # "tier" | "prepaid" | "blocked"

--- a/src/interfaces/teams.py
+++ b/src/interfaces/teams.py
@@ -8,15 +8,15 @@ from src.interfaces.payments import UtcDatetime
 class TeamCreateRequest(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     seat_prices: dict[str, float] = {}
-    extra_credits_monthly_cap: float | None = None
-    extra_credits_member_default_cap: float | None = None
+    extra_credits_monthly_cap: float | None = Field(default=None, ge=0)
+    extra_credits_member_default_cap: float | None = Field(default=None, ge=0)
 
 
 class TeamUpdateRequest(BaseModel):
     name: str | None = None
     seat_prices: dict[str, float] | None = None
-    extra_credits_monthly_cap: float | None = None
-    extra_credits_member_default_cap: float | None = None
+    extra_credits_monthly_cap: float | None = Field(default=None, ge=0)
+    extra_credits_member_default_cap: float | None = Field(default=None, ge=0)
 
 
 class TeamResponse(BaseModel):
@@ -59,12 +59,12 @@ class SeatChangeRequest(BaseModel):
 
 
 class CapsRequest(BaseModel):
-    extra_credits_monthly_cap: float | None = None
-    extra_credits_member_default_cap: float | None = None
+    extra_credits_monthly_cap: float | None = Field(default=None, ge=0)
+    extra_credits_member_default_cap: float | None = Field(default=None, ge=0)
 
 
 class MemberCapRequest(BaseModel):
-    extra_credits_cap_override: float | None = None
+    extra_credits_cap_override: float | None = Field(default=None, ge=0)
 
 
 class TeamTopupRequest(BaseModel):

--- a/src/interfaces/teams.py
+++ b/src/interfaces/teams.py
@@ -1,7 +1,8 @@
 import uuid
-from datetime import datetime
 
 from pydantic import BaseModel, EmailStr, Field
+
+from src.interfaces.payments import UtcDatetime
 
 
 class TeamCreateRequest(BaseModel):
@@ -37,7 +38,7 @@ class InviteResponse(BaseModel):
     email: str
     role: str
     status: str
-    expires_at: datetime
+    expires_at: UtcDatetime
 
 
 class AcceptInviteRequest(BaseModel):
@@ -78,7 +79,7 @@ class MemberResponse(BaseModel):
     role: str
     seat_tier: str | None
     seat_status: str | None
-    seat_period_end: datetime | None
+    seat_period_end: UtcDatetime | None
     extra_credits_cap_override: float | None
 
 
@@ -88,20 +89,20 @@ class TeamMeResponse(BaseModel):
     balance: float | None = None  # admins only
     members: list[MemberResponse] | None = None  # admins only
     own_seat_tier: str | None = None
-    own_seat_period_end: datetime | None = None
+    own_seat_period_end: UtcDatetime | None = None
 
 
 class LedgerChargeResponse(BaseModel):
     entry_type: str
     amount: float
     metadata: dict | None
-    created_at: datetime
+    created_at: UtcDatetime
 
 
 class LedgerTopupResponse(BaseModel):
     amount: float
     status: str
-    created_at: datetime
+    created_at: UtcDatetime
 
 
 class LedgerResponse(BaseModel):

--- a/src/interfaces/teams.py
+++ b/src/interfaces/teams.py
@@ -1,0 +1,119 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class TeamCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    seat_prices: dict[str, float] = {}
+    extra_credits_monthly_cap: float | None = None
+    extra_credits_member_default_cap: float | None = None
+
+
+class TeamUpdateRequest(BaseModel):
+    name: str | None = None
+    seat_prices: dict[str, float] | None = None
+    extra_credits_monthly_cap: float | None = None
+    extra_credits_member_default_cap: float | None = None
+
+
+class TeamResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    status: str
+    seat_prices: dict[str, float]
+    extra_credits_monthly_cap: float | None
+    extra_credits_member_default_cap: float | None
+
+
+class InviteRequest(BaseModel):
+    email: EmailStr
+    role: str = "member"
+
+
+class InviteResponse(BaseModel):
+    id: uuid.UUID
+    email: str
+    role: str
+    status: str
+    expires_at: datetime
+
+
+class AcceptInviteRequest(BaseModel):
+    token: str
+
+
+class RoleRequest(BaseModel):
+    role: str
+
+
+class SeatAssignRequest(BaseModel):
+    user_id: uuid.UUID
+    tier: str
+
+
+class SeatChangeRequest(BaseModel):
+    tier: str
+
+
+class CapsRequest(BaseModel):
+    extra_credits_monthly_cap: float | None = None
+    extra_credits_member_default_cap: float | None = None
+
+
+class MemberCapRequest(BaseModel):
+    extra_credits_cap_override: float | None = None
+
+
+class TeamTopupRequest(BaseModel):
+    amount: float = Field(gt=0)
+    redirect_base: str | None = None
+
+
+class MemberResponse(BaseModel):
+    user_id: uuid.UUID
+    email: str | None
+    display_name: str | None
+    role: str
+    seat_tier: str | None
+    seat_status: str | None
+    seat_period_end: datetime | None
+    extra_credits_cap_override: float | None
+
+
+class TeamMeResponse(BaseModel):
+    team: TeamResponse
+    role: str
+    balance: float | None = None  # admins only
+    members: list[MemberResponse] | None = None  # admins only
+    own_seat_tier: str | None = None
+    own_seat_period_end: datetime | None = None
+
+
+class LedgerChargeResponse(BaseModel):
+    entry_type: str
+    amount: float
+    metadata: dict | None
+    created_at: datetime
+
+
+class LedgerTopupResponse(BaseModel):
+    amount: float
+    status: str
+    created_at: datetime
+
+
+class LedgerResponse(BaseModel):
+    balance: float
+    topups: list[LedgerTopupResponse]
+    charges: list[LedgerChargeResponse]
+
+
+class MemberUsageResponse(BaseModel):
+    user_id: uuid.UUID
+    email: str | None
+    seat_tier: str | None
+    window_5h_used: float
+    weekly_used: float
+    extra_credits_month_to_date: float

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from src.routes.credits import router as credits_router
 from src.routes.liberclaw import router as liberclaw_router
 from src.routes.payments import router as payments_router
 from src.routes.stats import router as stats_router
+from src.routes.teams import router as teams_router
 from src.routes.x402 import router as x402_router
 from src.utils.cron import lifespan
 
@@ -37,3 +38,4 @@ app.include_router(chat_router)
 app.include_router(liberclaw_router)
 app.include_router(x402_router)
 app.include_router(payments_router)
+app.include_router(teams_router)

--- a/src/models/inference_call.py
+++ b/src/models/inference_call.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
@@ -30,6 +31,12 @@ class InferenceCall(Base):
     # paid from prepaid balance. Window usage sums this column, so prepaid-paid usage
     # never drains the allowance.
     tier_credits_used: Mapped[float] = mapped_column(Float, nullable=False, default=0.0, server_default="0")
+    # Set when part of this call was paid from a team balance (the extra-credits
+    # portion, credits_used - tier_credits_used). Monthly team/member cap
+    # aggregation sums that difference over rows with a team_id.
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID, ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+    )
     input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
     output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
     cached_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -45,6 +52,12 @@ class InferenceCall(Base):
         CheckConstraint("credits_used >= 0", name="check_credits_used_non_negative"),
         CheckConstraint("tier_credits_used >= 0", name="check_tier_credits_used_non_negative"),
         Index("ix_inference_calls_api_key_id_used_at", "api_key_id", "used_at"),
+        Index(
+            "ix_inference_calls_team_id_used_at",
+            "team_id",
+            "used_at",
+            postgresql_where=text("team_id IS NOT NULL"),
+        ),
     )
 
     def __init__(
@@ -57,6 +70,7 @@ class InferenceCall(Base):
         cached_tokens: int = 0,
         image_count: int = 0,
         tier_credits_used: float = 0.0,
+        team_id: uuid.UUID | None = None,
     ):
         self.api_key_id = api_key_id
         self.credits_used = credits_used
@@ -66,3 +80,4 @@ class InferenceCall(Base):
         self.cached_tokens = cached_tokens
         self.image_count = image_count
         self.tier_credits_used = tier_credits_used
+        self.team_id = team_id

--- a/src/models/plan_subscription.py
+++ b/src/models/plan_subscription.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import TIMESTAMP, UUID, Boolean, ForeignKey, Index, String, func, text
+from sqlalchemy import TIMESTAMP, UUID, Boolean, Float, ForeignKey, Index, String, func, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.models.base import Base
@@ -38,6 +38,13 @@ class PlanSubscription(Base):
     cancel_at_period_end: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     pending_tier: Mapped[str | None] = mapped_column(String, nullable=True)
     is_trial: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Teams: which team pays this seat (null for personal subs). Kept after the
+    # member leaves as audit history. seat_price_snapshot is the negotiated USD
+    # price actually charged for the current period (team.seat_prices is mutable).
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID, ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+    )
+    seat_price_snapshot: Mapped[float | None] = mapped_column(Float, nullable=True)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP, default=func.current_timestamp(), onupdate=func.current_timestamp()
@@ -73,6 +80,8 @@ class PlanSubscription(Base):
         cancel_at_period_end: bool = False,
         pending_tier: str | None = None,
         is_trial: bool = False,
+        team_id: uuid.UUID | None = None,
+        seat_price_snapshot: float | None = None,
     ):
         self.user_id = user_id
         self.tier = tier
@@ -86,3 +95,5 @@ class PlanSubscription(Base):
         self.cancel_at_period_end = cancel_at_period_end
         self.pending_tier = pending_tier
         self.is_trial = is_trial
+        self.team_id = team_id
+        self.seat_price_snapshot = seat_price_snapshot

--- a/src/models/team.py
+++ b/src/models/team.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, UUID, Float, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+
+class Team(Base):
+    """A sales-provisioned organization whose credit balance funds member seats.
+
+    ``seat_prices`` maps tier name -> negotiated monthly USD price. A tier absent
+    from a NON-empty map is not sellable to this team; an empty map means list
+    prices. Caps of ``None`` are treated as 0 (extra credits disabled).
+    """
+
+    __tablename__ = "teams"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="active")  # "active" | "suspended"
+    seat_prices: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    extra_credits_monthly_cap: Mapped[float | None] = mapped_column(Float, nullable=True)
+    extra_credits_member_default_cap: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP, default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    def __init__(self, name: str):
+        self.name = name
+        self.status = "active"
+        self.seat_prices = {}

--- a/src/models/team_credit_transaction.py
+++ b/src/models/team_credit_transaction.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, UUID, Boolean, CheckConstraint, Enum, Float, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.models.base import Base
+
+
+class TeamCreditTransaction(Base):
+    """A team-balance top-up, drained in place via ``amount_left`` (same algorithm
+    as ``credit_transactions``; kept as a separate table so user-balance queries
+    and constraints stay untouched)."""
+
+    __tablename__ = "team_credit_transactions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    team_id: Mapped[uuid.UUID] = mapped_column(UUID, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False)
+    external_reference: Mapped[str | None] = mapped_column(String, nullable=True, unique=True)
+    amount: Mapped[float] = mapped_column(Float, nullable=False)
+    amount_left: Mapped[float] = mapped_column(Float, nullable=False)
+    provider: Mapped[CreditTransactionProvider] = mapped_column(Enum(CreditTransactionProvider), nullable=False)
+    status: Mapped[CreditTransactionStatus] = mapped_column(
+        Enum(CreditTransactionStatus), nullable=False, default=CreditTransactionStatus.completed
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
+
+    __table_args__ = (
+        CheckConstraint("amount >= 0", name="check_team_tx_amount_non_negative"),
+        CheckConstraint("amount_left >= 0", name="check_team_tx_amount_left_non_negative"),
+        CheckConstraint("amount_left <= amount", name="check_team_tx_amount_left_not_exceeding"),
+    )
+
+    def __init__(
+        self,
+        team_id: uuid.UUID,
+        amount: float,
+        amount_left: float,
+        provider: CreditTransactionProvider,
+        external_reference: str | None = None,
+        status: CreditTransactionStatus = CreditTransactionStatus.completed,
+        is_active: bool = True,
+    ):
+        self.team_id = team_id
+        self.amount = amount
+        self.amount_left = amount_left
+        self.provider = provider
+        self.external_reference = external_reference
+        self.status = status
+        self.is_active = is_active

--- a/src/models/team_invite.py
+++ b/src/models/team_invite.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, UUID, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+
+class TeamInvite(Base):
+    """Email invite to a team. Token stored hashed (sha256), single-use via status."""
+
+    __tablename__ = "team_invites"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    team_id: Mapped[uuid.UUID] = mapped_column(UUID, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False)  # stored lowercased
+    role: Mapped[str] = mapped_column(String, nullable=False)
+    token_hash: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="pending")
+    expires_at: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
+
+    def __init__(self, team_id: uuid.UUID, email: str, role: str, token_hash: str, expires_at: datetime):
+        self.team_id = team_id
+        self.email = email.strip().lower()
+        self.role = role
+        self.token_hash = token_hash
+        self.expires_at = expires_at

--- a/src/models/team_ledger_entry.py
+++ b/src/models/team_ledger_entry.py
@@ -1,0 +1,32 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, UUID, CheckConstraint, Float, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+# entry_type values (plain strings, mirroring plan_subscription_event.event_type):
+#   "seat_charge_prorated" | "monthly_renewal" | "extra_credits_usage" | "adjustment"
+
+
+class TeamLedgerEntry(Base):
+    """Debit side of the team statement (top-ups live in team_credit_transactions)."""
+
+    __tablename__ = "team_ledger_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    team_id: Mapped[uuid.UUID] = mapped_column(UUID, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False)
+    entry_type: Mapped[str] = mapped_column(String, nullable=False)
+    amount: Mapped[float] = mapped_column(Float, nullable=False)  # positive USD debit
+    metadata_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
+
+    __table_args__ = (CheckConstraint("amount >= 0", name="check_ledger_amount_non_negative"),)
+
+    def __init__(self, team_id: uuid.UUID, entry_type: str, amount: float, metadata_json: dict | None = None):
+        self.team_id = team_id
+        self.entry_type = entry_type
+        self.amount = amount
+        self.metadata_json = metadata_json

--- a/src/models/team_membership.py
+++ b/src/models/team_membership.py
@@ -1,0 +1,42 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, UUID, Float, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+ROLE_ADMIN = "admin"
+ROLE_MEMBER = "member"
+
+
+class TeamMembership(Base):
+    """Pure membership (role + caps); seat state lives on plan_subscriptions.
+
+    ``user_id`` is UNIQUE: one team per user. ``extra_credits_cap_override``
+    of None falls back to the team's member default cap.
+    """
+
+    __tablename__ = "team_memberships"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    team_id: Mapped[uuid.UUID] = mapped_column(UUID, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    role: Mapped[str] = mapped_column(String, nullable=False, default=ROLE_MEMBER)
+    extra_credits_cap_override: Mapped[float | None] = mapped_column(Float, nullable=True)
+    invited_by: Mapped[uuid.UUID | None] = mapped_column(UUID, nullable=True)
+    joined_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
+
+    def __init__(
+        self,
+        team_id: uuid.UUID,
+        user_id: uuid.UUID,
+        role: str = ROLE_MEMBER,
+        invited_by: uuid.UUID | None = None,
+    ):
+        self.team_id = team_id
+        self.user_id = user_id
+        self.role = role
+        self.invited_by = invited_by

--- a/src/routes/credits/voucher.py
+++ b/src/routes/credits/voucher.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from fastapi import HTTPException
 from libertai_utils.chains.index import format_address
 from libertai_utils.interfaces.blockchain import LibertaiChain
+from sqlalchemy import select
 
 from src.interfaces.credits import (
     VoucherAddCreditsRequest,
@@ -12,12 +13,17 @@ from src.interfaces.credits import (
     VoucherChangeExpireRequest,
 )
 from src.models.base import AsyncSessionLocal
+from src.models.wallet_connection import WalletConnection
 from src.routes.credits import router
 from src.services.credit import CreditService
+from src.services.teams import TeamService
 from src.services.users import get_user_by_email
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
+
+# Team members hold no personal credits — vouchers to them are refused (mirrors /payments/topup).
+_MEMBER_BLOCKED = "Team members cannot hold personal credits — use your team balance"
 
 
 @router.post("/vouchers", description="Add credits via voucher to a wallet address or an email account")  # type: ignore
@@ -26,8 +32,10 @@ async def add_voucher_credits(voucher_request: VoucherAddCreditsRequest) -> bool
         # Existing email account only — never create one from a voucher. Credit by user id, no wallet.
         async with AsyncSessionLocal() as db:
             user = await get_user_by_email(db, voucher_request.email)
-        if user is None:
-            raise HTTPException(status_code=404, detail="No account found for this email")
+            if user is None:
+                raise HTTPException(status_code=404, detail="No account found for this email")
+            if await TeamService.get_membership(db, user.id) is not None:
+                raise HTTPException(status_code=400, detail=_MEMBER_BLOCKED)
         return await CreditService.add_credits_for_user(
             user_id=user.id,
             amount=voucher_request.amount,
@@ -35,10 +43,19 @@ async def add_voucher_credits(voucher_request: VoucherAddCreditsRequest) -> bool
             expired_at=voucher_request.expired_at,
         )
 
-    # Wallet recipient: resolve/create the user from the address (unchanged behaviour).
+    # Wallet recipient: block an existing member before crediting (a brand-new address
+    # has no user/membership yet, so it falls through to the unchanged create+credit path).
+    address = format_address(voucher_request.chain, voucher_request.address)
+    async with AsyncSessionLocal() as db:
+        wallet = (
+            await db.execute(select(WalletConnection).where(WalletConnection.address == address))
+        ).scalar_one_or_none()
+        if wallet is not None and await TeamService.get_membership(db, wallet.user_id) is not None:
+            raise HTTPException(status_code=400, detail=_MEMBER_BLOCKED)
+
     return await CreditService.add_credits(
         provider=CreditTransactionProvider.voucher,
-        address=format_address(voucher_request.chain, voucher_request.address),
+        address=address,
         amount=voucher_request.amount,
         expired_at=voucher_request.expired_at,
     )

--- a/src/routes/payments/payments.py
+++ b/src/routes/payments/payments.py
@@ -25,6 +25,7 @@ from src.interfaces.payments import (
 )
 from src.models.base import AsyncSessionLocal
 from src.models.plan_subscription import PlanSubscription
+from src.models.team import Team
 from src.models.user import User
 from src.models.wallet_connection import WalletConnection
 from src.routes.payments import router
@@ -81,6 +82,24 @@ async def _user_wallet_chains(db, user_id) -> list[str]:
 # Rails are split by account type: wallet users pay on-chain, email users pay by card.
 _WALLET_MUST_PAY_ONCHAIN = "Wallet accounts pay on-chain — use the credits provider"
 _CREDITS_REQUIRE_WALLET = "Credits subscriptions require a connected wallet"
+
+
+async def _reject_if_team_seat(db, user_id) -> None:
+    """Team seats are managed by the team, not the personal payment surface. Reject
+    before any provider/manager call so a seat holder can't mint an orphan sub."""
+    sub = (
+        await db.execute(
+            select(PlanSubscription).where(
+                PlanSubscription.user_id == user_id,
+                PlanSubscription.status.in_(["pending", "active", "overdue"]),
+            )
+        )
+    ).scalar_one_or_none()
+    if sub is not None and sub.provider == TEAM_CREDITS_PROVIDER:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This subscription is managed by your team",
+        )
 
 
 def _require_provider(provider_id: str):
@@ -214,6 +233,7 @@ async def subscribe(
 ) -> CheckoutResponse:
     if body.provider == "credits":
         async with AsyncSessionLocal() as db:
+            await _reject_if_team_seat(db, user.id)
             if not await _user_wallet_chains(db, user.id):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_CREDITS_REQUIRE_WALLET)
             try:
@@ -225,6 +245,7 @@ async def subscribe(
     provider = _require_provider(body.provider)
     currency = resolve_currency(request)
     async with AsyncSessionLocal() as db:
+        await _reject_if_team_seat(db, user.id)
         if await _user_wallet_chains(db, user.id):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_WALLET_MUST_PAY_ONCHAIN)
         manager = PaymentManager(provider, db)
@@ -252,6 +273,7 @@ async def upgrade(
 ) -> CheckoutResponse:
     if body.provider == "credits":
         async with AsyncSessionLocal() as db:
+            await _reject_if_team_seat(db, user.id)
             if not await _user_wallet_chains(db, user.id):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_CREDITS_REQUIRE_WALLET)
             try:
@@ -263,6 +285,7 @@ async def upgrade(
     provider = _require_provider(body.provider)
     currency = resolve_currency(request)
     async with AsyncSessionLocal() as db:
+        await _reject_if_team_seat(db, user.id)
         if await _user_wallet_chains(db, user.id):
             # A wallet user may still hold a fiat subscription opened before they
             # connected a wallet — let them upgrade it on its original provider.
@@ -421,6 +444,11 @@ async def get_subscription(user: User = Depends(get_current_user)) -> Subscripti
             )
         ).scalars().first()
         allowance = await get_allowance_state(db, user.id)
+        team_name = None
+        if sub is not None and sub.provider == TEAM_CREDITS_PROVIDER and sub.team_id is not None:
+            team_name = (
+                await db.execute(select(Team.name).where(Team.id == sub.team_id))
+            ).scalar_one_or_none()
 
     has_sub = sub is not None
     return SubscriptionResponse(
@@ -433,6 +461,7 @@ async def get_subscription(user: User = Depends(get_current_user)) -> Subscripti
         pending_tier=sub.pending_tier if sub else None,
         is_trial=sub.is_trial if sub else False,
         is_team_seat=(sub.provider == TEAM_CREDITS_PROVIDER) if sub else False,
+        team_name=team_name,
         allowed=allowance.allowed,
         source=allowance.source,
         window_5h_used=allowance.window_5h_used,

--- a/src/routes/payments/payments.py
+++ b/src/routes/payments/payments.py
@@ -102,6 +102,16 @@ async def _reject_if_team_seat(db, user_id) -> None:
         )
 
 
+async def _reject_if_team_personal_sub(db, user_id) -> None:
+    """Team members hold seats managed by their team, not personal subscriptions.
+    Reject before any service/provider call so a member can't mint a personal sub."""
+    if await TeamService.get_membership(db, user_id) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Team members cannot hold personal subscriptions — seats are managed by your team",
+        )
+
+
 def _require_provider(provider_id: str):
     try:
         provider = payment_registry.get(provider_id)
@@ -233,6 +243,7 @@ async def subscribe(
 ) -> CheckoutResponse:
     if body.provider == "credits":
         async with AsyncSessionLocal() as db:
+            await _reject_if_team_personal_sub(db, user.id)
             await _reject_if_team_seat(db, user.id)
             if not await _user_wallet_chains(db, user.id):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_CREDITS_REQUIRE_WALLET)
@@ -245,6 +256,7 @@ async def subscribe(
     provider = _require_provider(body.provider)
     currency = resolve_currency(request)
     async with AsyncSessionLocal() as db:
+        await _reject_if_team_personal_sub(db, user.id)
         await _reject_if_team_seat(db, user.id)
         if await _user_wallet_chains(db, user.id):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_WALLET_MUST_PAY_ONCHAIN)
@@ -273,6 +285,7 @@ async def upgrade(
 ) -> CheckoutResponse:
     if body.provider == "credits":
         async with AsyncSessionLocal() as db:
+            await _reject_if_team_personal_sub(db, user.id)
             await _reject_if_team_seat(db, user.id)
             if not await _user_wallet_chains(db, user.id):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_CREDITS_REQUIRE_WALLET)
@@ -285,6 +298,7 @@ async def upgrade(
     provider = _require_provider(body.provider)
     currency = resolve_currency(request)
     async with AsyncSessionLocal() as db:
+        await _reject_if_team_personal_sub(db, user.id)
         await _reject_if_team_seat(db, user.id)
         if await _user_wallet_chains(db, user.id):
             # A wallet user may still hold a fiat subscription opened before they

--- a/src/routes/payments/payments.py
+++ b/src/routes/payments/payments.py
@@ -36,6 +36,7 @@ from src.services.payments.credit_subscription import CreditSubscriptionService
 from src.services.payments.manager import PaymentManager
 from src.services.payments.registry import payment_registry
 from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+from src.services.teams import TeamService
 from src.subscription_tiers import DEFAULT_TIER, SUBSCRIPTION_TIERS
 from src.topup_packs import TOPUP_PACKS, get_pack
 from src.utils.cron import scheduler
@@ -174,6 +175,11 @@ async def topup(body: TopupRequest, request: Request, user: User = Depends(get_c
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="amount is required")
         usd_credits, charge_amount, charge_currency = body.amount, body.amount, "USD"
     async with AsyncSessionLocal() as db:
+        if await TeamService.get_membership(db, user.id) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Team members cannot hold personal credits — use your team balance",
+            )
         if await _user_wallet_chains(db, user.id):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/routes/payments/payments.py
+++ b/src/routes/payments/payments.py
@@ -35,6 +35,7 @@ from src.services.payments.base import PaymentProviderKind, UnsupportedCapabilit
 from src.services.payments.credit_subscription import CreditSubscriptionService
 from src.services.payments.manager import PaymentManager
 from src.services.payments.registry import payment_registry
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
 from src.subscription_tiers import DEFAULT_TIER, SUBSCRIPTION_TIERS
 from src.topup_packs import TOPUP_PACKS, get_pack
 from src.utils.cron import scheduler
@@ -299,6 +300,11 @@ async def downgrade(body: DowngradeRequest, user: User = Depends(get_current_use
                 )
             )
         ).scalar_one_or_none()
+        if sub is not None and sub.provider == TEAM_CREDITS_PROVIDER:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This subscription is managed by your team",
+            )
         if sub and sub.provider == "credits":
             try:
                 res = await CreditSubscriptionService.request_downgrade(db, user, body.tier)
@@ -337,6 +343,11 @@ async def cancel(user: User = Depends(get_current_user)) -> CancelResponse:
         ).scalar_one_or_none()
         if not sub:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No active subscription")
+        if sub is not None and sub.provider == TEAM_CREDITS_PROVIDER:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This subscription is managed by your team",
+            )
         if sub.provider == "credits":
             try:
                 res = await CreditSubscriptionService.cancel(db, user)
@@ -363,6 +374,11 @@ async def resume(user: User = Depends(get_current_user)) -> ResumeResponse:
         ).scalar_one_or_none()
         if not sub:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No active subscription")
+        if sub is not None and sub.provider == TEAM_CREDITS_PROVIDER:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This subscription is managed by your team",
+            )
         if sub.provider == "credits":
             try:
                 res = await CreditSubscriptionService.resume(db, user)
@@ -410,6 +426,7 @@ async def get_subscription(user: User = Depends(get_current_user)) -> Subscripti
         cancel_at_period_end=sub.cancel_at_period_end if sub else False,
         pending_tier=sub.pending_tier if sub else None,
         is_trial=sub.is_trial if sub else False,
+        is_team_seat=(sub.provider == TEAM_CREDITS_PROVIDER) if sub else False,
         allowed=allowance.allowed,
         source=allowance.source,
         window_5h_used=allowance.window_5h_used,

--- a/src/routes/teams/__init__.py
+++ b/src/routes/teams/__init__.py
@@ -1,0 +1,6 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/teams", tags=["Teams"])
+
+# Import handlers so they register on the router.
+from src.routes.teams import admin, teams  # noqa: E402,F401

--- a/src/routes/teams/admin.py
+++ b/src/routes/teams/admin.py
@@ -14,12 +14,14 @@ from src.interfaces.teams import (
     TeamUpdateRequest,
 )
 from src.models.base import AsyncSessionLocal
+from src.models.plan_subscription import PlanSubscription
 from src.models.team import Team
 from src.routes.teams import router
 from src.routes.teams.teams import _invite_response, _team_response, send_invite_email
 from src.services.auth import verify_admin_token
-from src.services.payments.team_seat_subscription import TeamSeatService
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER, TeamSeatService
 from src.services.teams import TeamService
+from src.subscription_tiers import PAID_TIERS
 
 
 @router.post(
@@ -56,6 +58,30 @@ async def staff_update_team(team_id: uuid.UUID, body: TeamUpdateRequest) -> Team
                 TeamService._validate_seat_prices(body.seat_prices)
             except ValueError as e:
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+            # A non-empty price map that drops a tier still in use would wedge that
+            # seat's renewal — reject it up front so pricing stays a superset of live seats.
+            if body.seat_prices:
+                active_seats = (
+                    await db.execute(
+                        select(PlanSubscription).where(
+                            PlanSubscription.team_id == team_id,
+                            PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                            PlanSubscription.status == "active",
+                        )
+                    )
+                ).scalars().all()
+                in_use = {s.tier for s in active_seats} | {
+                    s.pending_tier for s in active_seats if s.pending_tier
+                }
+                orphaned = sorted(t for t in in_use if t in PAID_TIERS and t not in body.seat_prices)
+                if orphaned:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            "Cannot drop tiers still used by active seats: "
+                            f"{', '.join(orphaned)}"
+                        ),
+                    )
             team.seat_prices = body.seat_prices
         if body.extra_credits_monthly_cap is not None:
             team.extra_credits_monthly_cap = body.extra_credits_monthly_cap

--- a/src/routes/teams/admin.py
+++ b/src/routes/teams/admin.py
@@ -1,0 +1,114 @@
+"""Staff-only team endpoints (``x-admin-token`` auth): provision teams, edit
+pricing/caps, suspend, and mint the first admin invite."""
+
+import uuid
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy import select
+
+from src.interfaces.teams import (
+    InviteRequest,
+    InviteResponse,
+    TeamCreateRequest,
+    TeamResponse,
+    TeamUpdateRequest,
+)
+from src.models.base import AsyncSessionLocal
+from src.models.team import Team
+from src.routes.teams import router
+from src.routes.teams.teams import _invite_response, _team_response, send_invite_email
+from src.services.auth import verify_admin_token
+from src.services.payments.team_seat_subscription import TeamSeatService
+from src.services.teams import TeamService
+
+
+@router.post(
+    "/admin", description="[staff] Create a team with negotiated pricing", dependencies=[Depends(verify_admin_token)]
+)  # type: ignore
+async def staff_create_team(body: TeamCreateRequest) -> TeamResponse:
+    async with AsyncSessionLocal() as db:
+        try:
+            team = await TeamService.create_team(
+                db,
+                body.name,
+                body.seat_prices,
+                body.extra_credits_monthly_cap,
+                body.extra_credits_member_default_cap,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return _team_response(team)
+
+
+@router.patch(
+    "/admin/{team_id}", description="[staff] Update a team's name/pricing/caps", dependencies=[Depends(verify_admin_token)]
+)  # type: ignore
+async def staff_update_team(team_id: uuid.UUID, body: TeamUpdateRequest) -> TeamResponse:
+    async with AsyncSessionLocal() as db:
+        team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+        if team is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        if body.name is not None:
+            team.name = body.name
+        if body.seat_prices is not None:
+            try:
+                TeamService._validate_seat_prices(body.seat_prices)
+            except ValueError as e:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+            team.seat_prices = body.seat_prices
+        if body.extra_credits_monthly_cap is not None:
+            team.extra_credits_monthly_cap = body.extra_credits_monthly_cap
+        if body.extra_credits_member_default_cap is not None:
+            team.extra_credits_member_default_cap = body.extra_credits_member_default_cap
+        await db.flush()
+        await db.commit()
+        return _team_response(team)
+
+
+@router.post(
+    "/admin/{team_id}/suspend", description="[staff] Suspend a team (expires all seats)", dependencies=[Depends(verify_admin_token)]
+)  # type: ignore
+async def staff_suspend_team(team_id: uuid.UUID) -> TeamResponse:
+    async with AsyncSessionLocal() as db:
+        team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+        if team is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        await TeamSeatService.suspend_team(db, team)
+        await db.commit()
+        return _team_response(team)
+
+
+@router.post(
+    "/admin/{team_id}/invites", description="[staff] Create the first admin invite", dependencies=[Depends(verify_admin_token)]
+)  # type: ignore
+async def staff_create_invite(team_id: uuid.UUID, body: InviteRequest) -> InviteResponse:
+    async with AsyncSessionLocal() as db:
+        team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+        if team is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        try:
+            invite, token = await TeamService.create_invite(db, team_id, body.email, body.role, "staff")
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+    await send_invite_email(team, invite.email, token)
+    return _invite_response(invite)
+
+
+@router.delete(
+    "/admin/{team_id}/members/{user_id}",
+    description="[staff] Remove a member (last-admin rule applies)",
+    dependencies=[Depends(verify_admin_token)],
+)  # type: ignore
+async def staff_remove_member(team_id: uuid.UUID, user_id: uuid.UUID) -> dict:
+    async with AsyncSessionLocal() as db:
+        team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+        if team is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        try:
+            await TeamService.remove_member(db, team_id, user_id, removed_by="staff")
+        except (ValueError, PermissionError) as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"status": "removed"}

--- a/src/routes/teams/admin.py
+++ b/src/routes/teams/admin.py
@@ -51,6 +51,9 @@ async def staff_update_team(team_id: uuid.UUID, body: TeamUpdateRequest) -> Team
         team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
         if team is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+        # Only touch fields the caller actually sent; an omitted field leaves the value
+        # unchanged, while an explicit null clears a cap (same semantics as /caps).
+        data = body.model_dump(exclude_unset=True)
         if body.name is not None:
             team.name = body.name
         if body.seat_prices is not None:
@@ -83,10 +86,10 @@ async def staff_update_team(team_id: uuid.UUID, body: TeamUpdateRequest) -> Team
                         ),
                     )
             team.seat_prices = body.seat_prices
-        if body.extra_credits_monthly_cap is not None:
-            team.extra_credits_monthly_cap = body.extra_credits_monthly_cap
-        if body.extra_credits_member_default_cap is not None:
-            team.extra_credits_member_default_cap = body.extra_credits_member_default_cap
+        if "extra_credits_monthly_cap" in data:
+            team.extra_credits_monthly_cap = data["extra_credits_monthly_cap"]
+        if "extra_credits_member_default_cap" in data:
+            team.extra_credits_member_default_cap = data["extra_credits_member_default_cap"]
         await db.flush()
         await db.commit()
         return _team_response(team)

--- a/src/routes/teams/teams.py
+++ b/src/routes/teams/teams.py
@@ -280,7 +280,7 @@ async def remove_team_member(
         await _load_team_as(db, team_id, user, admin=True)
         try:
             await TeamService.remove_member(db, team_id, user_id, removed_by=user.id)
-        except ValueError as e:
+        except (ValueError, PermissionError) as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
         await db.commit()
         return {"status": "removed"}
@@ -294,7 +294,7 @@ async def set_member_role(
         await _load_team_as(db, team_id, user, admin=True)
         try:
             await TeamService.set_role(db, team_id, user.id, user_id, body.role)
-        except ValueError as e:
+        except (ValueError, PermissionError) as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
         await db.commit()
         return {"status": "ok", "role": body.role}

--- a/src/routes/teams/teams.py
+++ b/src/routes/teams/teams.py
@@ -1,0 +1,494 @@
+"""Team-facing HTTP surface (members + team admins) and the seat-renewal cron.
+
+Object-level authz: every ``/teams/{team_id}/*`` handler resolves the caller's
+membership in THAT team via ``_load_team_as`` (admin flag when the action is
+admin-only), so a caller can never read or mutate a team they don't belong to.
+"""
+
+import uuid
+from datetime import datetime
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.interfaces.payments import CheckoutResponse
+from src.interfaces.teams import (
+    AcceptInviteRequest,
+    CapsRequest,
+    InviteRequest,
+    InviteResponse,
+    LedgerChargeResponse,
+    LedgerResponse,
+    LedgerTopupResponse,
+    MemberCapRequest,
+    MemberResponse,
+    MemberUsageResponse,
+    RoleRequest,
+    SeatAssignRequest,
+    SeatChangeRequest,
+    TeamMeResponse,
+    TeamResponse,
+    TeamTopupRequest,
+)
+from src.models.base import AsyncSessionLocal
+from src.models.plan_subscription import PlanSubscription
+from src.models.team import Team
+from src.models.team_credit_transaction import TeamCreditTransaction
+from src.models.team_ledger_entry import TeamLedgerEntry
+from src.models.team_membership import ROLE_ADMIN, TeamMembership
+from src.models.user import User
+from src.routes.teams import router
+from src.services.auth import get_current_user
+from src.services.entitlement import (
+    WINDOW_5H,
+    WINDOW_WEEKLY,
+    _month_start,
+    _team_extra_spend,
+    window_usage_by_users,
+)
+from src.services.payments.manager import PaymentManager
+from src.services.payments.registry import payment_registry
+from src.services.payments.team_seat_subscription import (
+    TEAM_CREDITS_PROVIDER,
+    TeamSeatService,
+    send_lapse_emails,
+)
+from src.services.team_credit import TeamCreditService
+from src.services.teams import TeamService
+from src.utils.cron import scheduler
+from src.utils.email import send_email
+from src.utils.frontend import resolve_frontend_base
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+# ------------------------------------------------------------------ helpers
+
+
+def _team_response(team: Team) -> TeamResponse:
+    return TeamResponse(
+        id=team.id,
+        name=team.name,
+        status=team.status,
+        seat_prices=team.seat_prices,
+        extra_credits_monthly_cap=team.extra_credits_monthly_cap,
+        extra_credits_member_default_cap=team.extra_credits_member_default_cap,
+    )
+
+
+def _invite_response(invite) -> InviteResponse:
+    return InviteResponse(
+        id=invite.id,
+        email=invite.email,
+        role=invite.role,
+        status=invite.status,
+        expires_at=invite.expires_at,
+    )
+
+
+def _checkout_redirect(redirect_base: str | None) -> str:
+    """Post-checkout return URL on the app the admin paid from (chat vs console)."""
+    return f"{resolve_frontend_base(redirect_base)}/payment/callback"
+
+
+def _require_provider(provider_id: str):
+    """Duplicated (intentionally) from the payments route rather than importing a
+    private name; keeps the team surface decoupled from that module's internals."""
+    try:
+        provider = payment_registry.get(provider_id)
+    except KeyError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown provider: {provider_id}")
+    if not provider.descriptor().enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Provider {provider_id} is not configured",
+        )
+    return provider
+
+
+async def send_invite_email(team: Team, email: str, token: str) -> None:
+    """Fire-and-forget invite mail. Building the link or sending must never break
+    the request (mirrors ``send_magic_link_email``)."""
+    try:
+        link = f"{resolve_frontend_base(None)}/teams/invite?token={token}"
+    except ValueError:
+        logger.error(f"FRONTEND_URL is not configured; cannot send team-invite email to {email}")
+        return
+    await send_email(
+        [email],
+        f"You're invited to {team.name} on LibertAI",
+        (
+            f"<h2>You've been invited to join {team.name} on LibertAI</h2>"
+            f'<p><a href="{link}">Accept your invitation</a> (link expires soon).</p>'
+        ),
+    )
+
+
+async def _load_team_as(
+    db: AsyncSession, team_id: uuid.UUID, user: User, admin: bool
+) -> tuple[Team, TeamMembership]:
+    """Object-level authz: the caller must be a member (admin if required) of THIS team."""
+    try:
+        membership = await TeamService.require_membership(db, team_id, user.id, admin=admin)
+    except PermissionError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    team = (await db.execute(select(Team).where(Team.id == team_id))).scalar_one_or_none()
+    if team is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+    return team, membership
+
+
+async def _list_members(db: AsyncSession, team_id: uuid.UUID) -> list[MemberResponse]:
+    rows = (
+        await db.execute(
+            select(TeamMembership, User, PlanSubscription)
+            .join(User, User.id == TeamMembership.user_id)
+            .outerjoin(
+                PlanSubscription,
+                and_(
+                    PlanSubscription.user_id == TeamMembership.user_id,
+                    PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                    PlanSubscription.status == "active",
+                ),
+            )
+            .where(TeamMembership.team_id == team_id)
+        )
+    ).all()
+    return [
+        MemberResponse(
+            user_id=m.user_id,
+            email=u.email,
+            display_name=u.display_name,
+            role=m.role,
+            seat_tier=s.tier if s else None,
+            seat_status=s.status if s else None,
+            seat_period_end=s.current_period_end if s else None,
+            extra_credits_cap_override=m.extra_credits_cap_override,
+        )
+        for m, u, s in rows
+    ]
+
+
+# ------------------------------------------------------------------ cron
+
+
+@scheduler.scheduled_job("interval", hours=1)
+async def renew_team_seats() -> int:
+    """Monthly seat renewals (idempotent hourly sweep, like renew_credit_subscriptions).
+
+    Lapse emails go out AFTER the commit — a mail must never sit inside the txn."""
+    async with AsyncSessionLocal() as db:
+        count, notices = await TeamSeatService.process_renewals(db)
+        await db.commit()
+    await send_lapse_emails(notices)
+    return count
+
+
+# ------------------------------------------------------------------ member endpoints
+
+
+@router.get("/me", description="Caller's team (with balance + members for admins)")  # type: ignore
+async def get_my_team(user: User = Depends(get_current_user)) -> TeamMeResponse:
+    async with AsyncSessionLocal() as db:
+        membership = await TeamService.get_membership(db, user.id)
+        if membership is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="You are not a member of any team")
+        team = (await db.execute(select(Team).where(Team.id == membership.team_id))).scalar_one()
+        own_seat = (
+            await db.execute(
+                select(PlanSubscription).where(
+                    PlanSubscription.user_id == user.id,
+                    PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                    PlanSubscription.status == "active",
+                )
+            )
+        ).scalar_one_or_none()
+        resp = TeamMeResponse(
+            team=_team_response(team),
+            role=membership.role,
+            own_seat_tier=own_seat.tier if own_seat else None,
+            own_seat_period_end=own_seat.current_period_end if own_seat else None,
+        )
+        # Ledger/balance and the member roster are admin-only.
+        if membership.role == ROLE_ADMIN:
+            resp.balance = await TeamCreditService.get_balance(db, team.id)
+            resp.members = await _list_members(db, team.id)
+        return resp
+
+
+@router.post("/invites/accept", description="Accept a team invite (email must match)")  # type: ignore
+async def accept_invite(body: AcceptInviteRequest, user: User = Depends(get_current_user)) -> dict:
+    async with AsyncSessionLocal() as db:
+        try:
+            membership = await TeamService.accept_invite(db, body.token, user)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"team_id": str(membership.team_id), "role": membership.role}
+
+
+@router.post("/leave", description="Leave your team (last admin cannot leave)")  # type: ignore
+async def leave_team(user: User = Depends(get_current_user)) -> dict:
+    async with AsyncSessionLocal() as db:
+        try:
+            await TeamService.leave(db, user.id)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"status": "left"}
+
+
+# ------------------------------------------------------------------ team-admin endpoints
+
+
+@router.post("/{team_id}/invites", description="[admin] Invite a member by email")  # type: ignore
+async def create_team_invite(
+    team_id: uuid.UUID, body: InviteRequest, user: User = Depends(get_current_user)
+) -> InviteResponse:
+    async with AsyncSessionLocal() as db:
+        team, _ = await _load_team_as(db, team_id, user, admin=True)
+        try:
+            invite, token = await TeamService.create_invite(db, team_id, body.email, body.role, invited_by=user.id)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+    await send_invite_email(team, invite.email, token)
+    return _invite_response(invite)
+
+
+@router.delete("/{team_id}/invites/{invite_id}", description="[admin] Revoke a pending invite")  # type: ignore
+async def revoke_team_invite(
+    team_id: uuid.UUID, invite_id: uuid.UUID, user: User = Depends(get_current_user)
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        await _load_team_as(db, team_id, user, admin=True)
+        try:
+            await TeamService.revoke_invite(db, team_id, invite_id)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"status": "revoked"}
+
+
+@router.delete("/{team_id}/members/{user_id}", description="[admin] Remove a member")  # type: ignore
+async def remove_team_member(
+    team_id: uuid.UUID, user_id: uuid.UUID, user: User = Depends(get_current_user)
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        await _load_team_as(db, team_id, user, admin=True)
+        try:
+            await TeamService.remove_member(db, team_id, user_id, removed_by=user.id)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"status": "removed"}
+
+
+@router.post("/{team_id}/members/{user_id}/role", description="[admin] Set a member's role")  # type: ignore
+async def set_member_role(
+    team_id: uuid.UUID, user_id: uuid.UUID, body: RoleRequest, user: User = Depends(get_current_user)
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        await _load_team_as(db, team_id, user, admin=True)
+        try:
+            await TeamService.set_role(db, team_id, user.id, user_id, body.role)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"status": "ok", "role": body.role}
+
+
+@router.post("/{team_id}/seats", description="[admin] Assign a seat to a member")  # type: ignore
+async def assign_seat(
+    team_id: uuid.UUID, body: SeatAssignRequest, user: User = Depends(get_current_user)
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        team, _ = await _load_team_as(db, team_id, user, admin=True)
+        try:
+            seat = await TeamSeatService.assign_seat(db, team, body.user_id, body.tier)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"seat_id": str(seat.id), "tier": seat.tier}
+
+
+@router.patch("/{team_id}/seats/{user_id}", description="[admin] Change a member's seat tier")  # type: ignore
+async def change_seat(
+    team_id: uuid.UUID, user_id: uuid.UUID, body: SeatChangeRequest, user: User = Depends(get_current_user)
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        team, _ = await _load_team_as(db, team_id, user, admin=True)
+        try:
+            seat = await TeamSeatService.change_tier(db, team, user_id, body.tier)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"seat_id": str(seat.id), "tier": seat.tier, "pending_tier": seat.pending_tier}
+
+
+@router.delete("/{team_id}/seats/{user_id}", description="[admin] Cancel a member's seat at period end")  # type: ignore
+async def cancel_seat(
+    team_id: uuid.UUID, user_id: uuid.UUID, user: User = Depends(get_current_user)
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        team, _ = await _load_team_as(db, team_id, user, admin=True)
+        try:
+            await TeamSeatService.cancel_seat(db, team, user_id)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+        return {"status": "cancel_scheduled"}
+
+
+@router.patch("/{team_id}/caps", description="[admin] Set the team's extra-credits caps")  # type: ignore
+async def set_team_caps(
+    team_id: uuid.UUID, body: CapsRequest, user: User = Depends(get_current_user)
+) -> TeamResponse:
+    async with AsyncSessionLocal() as db:
+        team, _ = await _load_team_as(db, team_id, user, admin=True)
+        team.extra_credits_monthly_cap = body.extra_credits_monthly_cap
+        team.extra_credits_member_default_cap = body.extra_credits_member_default_cap
+        await db.flush()
+        await db.commit()
+        return _team_response(team)
+
+
+@router.patch("/{team_id}/members/{user_id}/cap", description="[admin] Override a member's extra-credits cap")  # type: ignore
+async def set_member_cap(
+    team_id: uuid.UUID, user_id: uuid.UUID, body: MemberCapRequest, user: User = Depends(get_current_user)
+) -> MemberResponse:
+    async with AsyncSessionLocal() as db:
+        await _load_team_as(db, team_id, user, admin=True)
+        target = (
+            await db.execute(
+                select(TeamMembership).where(
+                    TeamMembership.team_id == team_id, TeamMembership.user_id == user_id
+                )
+            )
+        ).scalar_one_or_none()
+        if target is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
+        target.extra_credits_cap_override = body.extra_credits_cap_override
+        await db.flush()
+        target_user = (await db.execute(select(User).where(User.id == user_id))).scalar_one()
+        seat = (
+            await db.execute(
+                select(PlanSubscription).where(
+                    PlanSubscription.user_id == user_id,
+                    PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                    PlanSubscription.status == "active",
+                )
+            )
+        ).scalar_one_or_none()
+        await db.commit()
+        return MemberResponse(
+            user_id=target.user_id,
+            email=target_user.email,
+            display_name=target_user.display_name,
+            role=target.role,
+            seat_tier=seat.tier if seat else None,
+            seat_status=seat.status if seat else None,
+            seat_period_end=seat.current_period_end if seat else None,
+            extra_credits_cap_override=target.extra_credits_cap_override,
+        )
+
+
+@router.get("/{team_id}/ledger", description="[admin] Team balance + recent top-ups and charges")  # type: ignore
+async def get_ledger(team_id: uuid.UUID, user: User = Depends(get_current_user)) -> LedgerResponse:
+    async with AsyncSessionLocal() as db:
+        await _load_team_as(db, team_id, user, admin=True)
+        balance = await TeamCreditService.get_balance(db, team_id)
+        topups = (
+            await db.execute(
+                select(TeamCreditTransaction)
+                .where(TeamCreditTransaction.team_id == team_id)
+                .order_by(TeamCreditTransaction.created_at.desc())
+                .limit(100)
+            )
+        ).scalars().all()
+        charges = (
+            await db.execute(
+                select(TeamLedgerEntry)
+                .where(TeamLedgerEntry.team_id == team_id)
+                .order_by(TeamLedgerEntry.created_at.desc())
+                .limit(100)
+            )
+        ).scalars().all()
+        return LedgerResponse(
+            balance=balance,
+            topups=[
+                LedgerTopupResponse(amount=t.amount, status=t.status.value, created_at=t.created_at)
+                for t in topups
+            ],
+            charges=[
+                LedgerChargeResponse(
+                    entry_type=c.entry_type, amount=c.amount, metadata=c.metadata_json, created_at=c.created_at
+                )
+                for c in charges
+            ],
+        )
+
+
+@router.get("/{team_id}/usage", description="[admin] Per-member window usage + extra-credits spend")  # type: ignore
+async def get_usage(team_id: uuid.UUID, user: User = Depends(get_current_user)) -> list[MemberUsageResponse]:
+    now = datetime.now()
+    month_start = _month_start(now)
+    async with AsyncSessionLocal() as db:
+        await _load_team_as(db, team_id, user, admin=True)
+        members = (
+            await db.execute(
+                select(TeamMembership, User)
+                .join(User, User.id == TeamMembership.user_id)
+                .where(TeamMembership.team_id == team_id)
+            )
+        ).all()
+        user_ids = {m.user_id for m, _ in members}
+        seats = {
+            s.user_id: s
+            for s in (
+                await db.execute(
+                    select(PlanSubscription).where(
+                        PlanSubscription.team_id == team_id,
+                        PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                        PlanSubscription.status == "active",
+                    )
+                )
+            ).scalars().all()
+        }
+        used_5h = await window_usage_by_users(db, user_ids, WINDOW_5H, now)
+        used_weekly = await window_usage_by_users(db, user_ids, WINDOW_WEEKLY, now)
+        return [
+            MemberUsageResponse(
+                user_id=m.user_id,
+                email=u.email,
+                seat_tier=seats[m.user_id].tier if m.user_id in seats else None,
+                window_5h_used=used_5h.get(m.user_id, 0.0),
+                weekly_used=used_weekly.get(m.user_id, 0.0),
+                extra_credits_month_to_date=await _team_extra_spend(
+                    db, team_id, month_start, user_id=m.user_id
+                ),
+            )
+            for m, u in members
+        ]
+
+
+@router.post("/{team_id}/topup", description="[admin] Open a checkout to fund the team balance")  # type: ignore
+async def team_topup(
+    team_id: uuid.UUID, body: TeamTopupRequest, user: User = Depends(get_current_user)
+) -> CheckoutResponse:
+    async with AsyncSessionLocal() as db:
+        team, _ = await _load_team_as(db, team_id, user, admin=True)
+        provider = _require_provider("revolut")
+        try:
+            result = await PaymentManager(provider, db).start_team_topup(
+                team,
+                user.email,
+                _checkout_redirect(body.redirect_base),
+                usd_credits=body.amount,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        await db.commit()
+    return CheckoutResponse(checkout_url=result.checkout_url)

--- a/src/routes/teams/teams.py
+++ b/src/routes/teams/teams.py
@@ -348,8 +348,13 @@ async def set_team_caps(
 ) -> TeamResponse:
     async with AsyncSessionLocal() as db:
         team, _ = await _load_team_as(db, team_id, user, admin=True)
-        team.extra_credits_monthly_cap = body.extra_credits_monthly_cap
-        team.extra_credits_member_default_cap = body.extra_credits_member_default_cap
+        # Only touch fields the caller actually sent; an omitted field must not silently
+        # clear a cap (explicit null still clears — that's how you disable one).
+        data = body.model_dump(exclude_unset=True)
+        if "extra_credits_monthly_cap" in data:
+            team.extra_credits_monthly_cap = data["extra_credits_monthly_cap"]
+        if "extra_credits_member_default_cap" in data:
+            team.extra_credits_member_default_cap = data["extra_credits_member_default_cap"]
         await db.flush()
         await db.commit()
         return _team_response(team)

--- a/src/routes/teams/teams.py
+++ b/src/routes/teams/teams.py
@@ -182,6 +182,7 @@ async def renew_team_seats() -> int:
     async with AsyncSessionLocal() as db:
         count, notices = await TeamSeatService.process_renewals(db)
         await db.commit()
+    # Best-effort: a crash between commit and send loses the notice (seats stay expired; admins see it in the console).
     await send_lapse_emails(notices)
     return count
 

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -14,6 +14,7 @@ from src.models.base import AsyncSessionLocal
 from src.models.inference_call import InferenceCall
 from src.services.api_key_pool import ApiKeyPoolService
 from src.services.credit import CreditService
+from src.services.team_credit import TeamCreditService
 from src.services.entitlement import (
     CHARGEABLE_KEY_TYPES,
     WINDOW_5H,
@@ -21,7 +22,9 @@ from src.services.entitlement import (
     active_tiers_by_users,
     compute_source,
     get_allowance_state,
+    get_team_extra_context,
     open_windows,
+    team_extra_available_by_users,
     window_usage_by_users,
 )
 from src.subscription_tiers import DEFAULT_TIER, get_tier
@@ -595,6 +598,8 @@ class ApiKeyService:
                 window_5h_usage = await window_usage_by_users(db, user_ids, WINDOW_5H, now)
                 weekly_usage = await window_usage_by_users(db, user_ids, WINDOW_WEEKLY, now)
                 active_tiers = await active_tiers_by_users(db, user_ids)
+                # Team members gate on team extra-credits headroom, not personal balance.
+                team_contexts = await team_extra_available_by_users(db, user_ids, now)
 
                 # Pre-fetch current month usage for API keys with monthly limits
                 api_keys_with_limits = [
@@ -688,11 +693,13 @@ class ApiKeyService:
                         # Dual-window entitlement: free tier (or larger paid windows) by
                         # default, prepaid balance as the overflow path.
                         tier = get_tier(active_tiers.get(key.user_id, DEFAULT_TIER))
+                        ctx = team_contexts.get(key.user_id)
                         source = compute_source(
                             tier,
                             window_5h_usage.get(key.user_id, 0.0),
                             weekly_usage.get(key.user_id, 0.0),
-                            balances.get(key.user_id, 0.0),
+                            0.0 if ctx is not None else balances.get(key.user_id, 0.0),
+                            team_extra_available=ctx.available if ctx is not None else 0.0,
                         )
                         if source == "blocked":
                             continue
@@ -765,6 +772,7 @@ class ApiKeyService:
                 # only while both have room. The split is persisted on the row so window
                 # usage sums never count the prepaid-paid portion against the allowance.
                 tier_covered = 0.0
+                team_ctx = None
                 if chargeable_user_id is not None:
                     # Open/reset this user's fixed windows so usage accrues against them.
                     await open_windows(db, chargeable_user_id, now)
@@ -772,6 +780,16 @@ class ApiKeyService:
                     remaining_5h = max(0.0, state.window_5h_limit - state.window_5h_used)
                     remaining_weekly = max(0.0, state.weekly_limit - state.weekly_used)
                     tier_covered = min(credits_used, remaining_5h, remaining_weekly)
+                    # For members, resolve the team extra-credits headroom so the row can be
+                    # stamped and the overflow drained from the team (not personal) balance.
+                    team_ctx = await get_team_extra_context(db, chargeable_user_id, now)
+
+                overflow_preview = credits_used - tier_covered
+                stamped_team_id = (
+                    team_ctx.team_id
+                    if team_ctx is not None and overflow_preview > 0 and team_ctx.available > 0
+                    else None
+                )
 
                 usage = InferenceCall(
                     api_key_id=api_key.id,
@@ -782,6 +800,7 @@ class ApiKeyService:
                     cached_tokens=cached_tokens,
                     image_count=image_count,
                     tier_credits_used=tier_covered,
+                    team_id=stamped_team_id,
                 )
                 usage.used_at = now
                 db.add(usage)
@@ -792,11 +811,32 @@ class ApiKeyService:
                 if chargeable_user_id is not None:
                     overflow = credits_used - tier_covered
                     if overflow > 0:
-                        # Post-hoc billing: the call already happened, so capture what the
-                        # balance can cover rather than nothing if it falls short.
-                        success = await CreditService.use_credits(chargeable_user_id, overflow, allow_partial=True)
-                        if not success:
-                            logger.warning(f"Failed to fully deduct {overflow} credits for API key {key}")
+                        if team_ctx is not None:
+                            # Members never spend personal credits: drain the team
+                            # balance up to the capped headroom (post-hoc call).
+                            drain = min(overflow, team_ctx.available)
+                            if drain > 0:
+                                async with AsyncSessionLocal() as team_db:
+                                    await TeamCreditService.use_credits(
+                                        team_db, team_ctx.team_id, drain, allow_partial=True
+                                    )
+                                    await TeamCreditService.log(
+                                        team_db, team_ctx.team_id, "extra_credits_usage", drain,
+                                        {"user_id": str(chargeable_user_id)},
+                                    )
+                                    await team_db.commit()
+                            if drain < overflow:
+                                logger.warning(
+                                    f"Team caps left {overflow - drain} credits uncollected for key {key}"
+                                )
+                        else:
+                            # Post-hoc billing: the call already happened, so capture what the
+                            # balance can cover rather than nothing if it falls short.
+                            success = await CreditService.use_credits(
+                                chargeable_user_id, overflow, allow_partial=True
+                            )
+                            if not success:
+                                logger.warning(f"Failed to fully deduct {overflow} credits for API key {key}")
 
                 return True
 

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -804,39 +804,41 @@ class ApiKeyService:
                 )
                 usage.used_at = now
                 db.add(usage)
+
+                # Members never spend personal credits: drain the team balance up to the
+                # capped headroom. This runs in the SAME transaction as the usage-row insert
+                # so a stamped call and its debit commit atomically (a crash between them
+                # can't leave a stamped call with no debit).
+                overflow = credits_used - tier_covered if chargeable_user_id is not None else 0.0
+                if chargeable_user_id is not None and team_ctx is not None and overflow > 0:
+                    drain = min(overflow, team_ctx.available)
+                    if drain > 0:
+                        # Log the amount actually deducted (bounded by the live balance),
+                        # not the intended drain, so the ledger never overstates.
+                        balance_before = await TeamCreditService.get_balance(db, team_ctx.team_id)
+                        await TeamCreditService.use_credits(
+                            db, team_ctx.team_id, drain, allow_partial=True
+                        )
+                        await TeamCreditService.log(
+                            db, team_ctx.team_id, "extra_credits_usage", min(drain, balance_before),
+                            {"user_id": str(chargeable_user_id)},
+                        )
+                    if drain < overflow:
+                        logger.warning(
+                            f"Team caps left {overflow - drain} credits uncollected for key {key}"
+                        )
+
                 await db.commit()
 
-                # Deduct the overflow from the user's prepaid balance (skip for liberclaw,
-                # x402 and the shared free chat key).
-                if chargeable_user_id is not None:
-                    overflow = credits_used - tier_covered
-                    if overflow > 0:
-                        if team_ctx is not None:
-                            # Members never spend personal credits: drain the team
-                            # balance up to the capped headroom (post-hoc call).
-                            drain = min(overflow, team_ctx.available)
-                            if drain > 0:
-                                async with AsyncSessionLocal() as team_db:
-                                    await TeamCreditService.use_credits(
-                                        team_db, team_ctx.team_id, drain, allow_partial=True
-                                    )
-                                    await TeamCreditService.log(
-                                        team_db, team_ctx.team_id, "extra_credits_usage", drain,
-                                        {"user_id": str(chargeable_user_id)},
-                                    )
-                                    await team_db.commit()
-                            if drain < overflow:
-                                logger.warning(
-                                    f"Team caps left {overflow - drain} credits uncollected for key {key}"
-                                )
-                        else:
-                            # Post-hoc billing: the call already happened, so capture what the
-                            # balance can cover rather than nothing if it falls short.
-                            success = await CreditService.use_credits(
-                                chargeable_user_id, overflow, allow_partial=True
-                            )
-                            if not success:
-                                logger.warning(f"Failed to fully deduct {overflow} credits for API key {key}")
+                # Personal (non-member) overflow stays a post-hoc, separate-session debit:
+                # the call already happened, so capture what the balance can cover rather than
+                # nothing if it falls short.
+                if chargeable_user_id is not None and team_ctx is None and overflow > 0:
+                    success = await CreditService.use_credits(
+                        chargeable_user_id, overflow, allow_partial=True
+                    )
+                    if not success:
+                        logger.warning(f"Failed to fully deduct {overflow} credits for API key {key}")
 
                 return True
 

--- a/src/services/entitlement.py
+++ b/src/services/entitlement.py
@@ -148,6 +148,7 @@ async def get_team_extra_context(
     member_spent = await _team_extra_spend(db, team.id, month_start, user_id=user_id)
     team_spent = await _team_extra_spend(db, team.id, month_start)
     balance = await TeamCreditService.get_balance(db, team.id)
+    # Caps are best-effort under concurrency: spend is read without locks, so N members racing can collectively overshoot by up to (N-1) calls' overflow, bounded by the team balance.
     available = max(0.0, min(member_cap - member_spent, team_cap - team_spent, balance))
     return TeamExtraContext(team_id=team.id, available=available)
 

--- a/src/services/entitlement.py
+++ b/src/services/entitlement.py
@@ -61,20 +61,189 @@ class AllowanceState:
     weekly_used: float
     weekly_limit: float
     prepaid_balance: float
-    source: str  # "tier" | "prepaid" | "blocked"
+    source: str  # "tier" | "prepaid" | "team" | "blocked"
     # When each active window resets (None if no active window of that kind).
     window_5h_resets_at: datetime | None
     weekly_resets_at: datetime | None
 
 
-def compute_source(tier: TierConfig, usage_5h: float, usage_weekly: float, prepaid: float) -> str:
-    """Decide which path covers the *next* call: tier window, prepaid, or none."""
+@dataclass
+class TeamExtraContext:
+    team_id: uuid.UUID
+    available: float
+
+
+def compute_source(
+    tier: TierConfig,
+    usage_5h: float,
+    usage_weekly: float,
+    prepaid: float,
+    team_extra_available: float = 0.0,
+) -> str:
+    """Decide which path covers the *next* call: tier window, prepaid, team extra, or none."""
     within_window = usage_5h < tier.window_5h_credits and usage_weekly < tier.weekly_credits
     if within_window:
         return "tier"
     if prepaid >= PREPAID_MIN:
         return "prepaid"
+    if team_extra_available >= PREPAID_MIN:
+        return "team"
     return "blocked"
+
+
+def _month_start(now: datetime) -> datetime:
+    return datetime(now.year, now.month, 1)
+
+
+async def _team_extra_spend(
+    db: AsyncSession, team_id: uuid.UUID, month_start: datetime, user_id: uuid.UUID | None = None
+) -> float:
+    """Month-to-date team-funded spend: SUM(credits_used - tier_credits_used) over
+    team-stamped calls. NEVER sum credits_used alone — the window-covered portion
+    of a straddling call must not eat the cap."""
+    stmt = select(
+        sql_func.coalesce(
+            sql_func.sum(InferenceCall.credits_used - InferenceCall.tier_credits_used), 0.0
+        )
+    ).where(InferenceCall.team_id == team_id, InferenceCall.used_at >= month_start)
+    if user_id is not None:
+        stmt = stmt.join(ApiKeyDB, InferenceCall.api_key_id == ApiKeyDB.id).where(
+            ApiKeyDB.user_id == user_id
+        )
+    return float((await db.execute(stmt)).scalar() or 0.0)
+
+
+async def get_team_extra_context(
+    db: AsyncSession, user_id: uuid.UUID, now: datetime
+) -> TeamExtraContext | None:
+    """Extra-credits headroom for a team member (None = not a member).
+
+    available = max(0, min(member cap headroom, team cap headroom, team balance)).
+    Caps of None mean 0 (disabled). Suspended teams always yield 0.
+    """
+    from src.models.team import Team
+    from src.models.team_membership import TeamMembership
+    from src.services.team_credit import TeamCreditService
+
+    row = (
+        await db.execute(
+            select(TeamMembership, Team)
+            .join(Team, Team.id == TeamMembership.team_id)
+            .where(TeamMembership.user_id == user_id)
+        )
+    ).first()
+    if row is None:
+        return None
+    membership, team = row
+    if team.status != "active":
+        return TeamExtraContext(team_id=team.id, available=0.0)
+
+    member_cap = (
+        membership.extra_credits_cap_override
+        if membership.extra_credits_cap_override is not None
+        else (team.extra_credits_member_default_cap or 0.0)
+    )
+    team_cap = team.extra_credits_monthly_cap or 0.0
+    month_start = _month_start(now)
+    member_spent = await _team_extra_spend(db, team.id, month_start, user_id=user_id)
+    team_spent = await _team_extra_spend(db, team.id, month_start)
+    balance = await TeamCreditService.get_balance(db, team.id)
+    available = max(0.0, min(member_cap - member_spent, team_cap - team_spent, balance))
+    return TeamExtraContext(team_id=team.id, available=available)
+
+
+async def team_extra_available_by_users(
+    db: AsyncSession, user_ids: set[uuid.UUID], now: datetime
+) -> dict[uuid.UUID, TeamExtraContext]:
+    """Batched ``get_team_extra_context`` (gateway path — no per-key N+1)."""
+    from src.models.team import Team
+    from src.models.team_credit_transaction import TeamCreditTransaction
+    from src.models.team_membership import TeamMembership
+
+    if not user_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(TeamMembership, Team)
+            .join(Team, Team.id == TeamMembership.team_id)
+            .where(TeamMembership.user_id.in_(user_ids))
+        )
+    ).all()
+    if not rows:
+        return {}
+    team_ids = {team.id for _, team in rows}
+    month_start = _month_start(now)
+
+    member_spend_rows = (
+        await db.execute(
+            select(
+                ApiKeyDB.user_id,
+                sql_func.coalesce(
+                    sql_func.sum(InferenceCall.credits_used - InferenceCall.tier_credits_used), 0.0
+                ),
+            )
+            .join(InferenceCall, InferenceCall.api_key_id == ApiKeyDB.id)
+            .where(
+                InferenceCall.team_id.in_(team_ids),
+                InferenceCall.used_at >= month_start,
+                ApiKeyDB.user_id.in_(user_ids),
+            )
+            .group_by(ApiKeyDB.user_id)
+        )
+    ).all()
+    member_spent = {r[0]: float(r[1]) for r in member_spend_rows}
+
+    team_spend_rows = (
+        await db.execute(
+            select(
+                InferenceCall.team_id,
+                sql_func.coalesce(
+                    sql_func.sum(InferenceCall.credits_used - InferenceCall.tier_credits_used), 0.0
+                ),
+            )
+            .where(InferenceCall.team_id.in_(team_ids), InferenceCall.used_at >= month_start)
+            .group_by(InferenceCall.team_id)
+        )
+    ).all()
+    team_spent = {r[0]: float(r[1]) for r in team_spend_rows}
+
+    balance_rows = (
+        await db.execute(
+            select(
+                TeamCreditTransaction.team_id,
+                sql_func.coalesce(sql_func.sum(TeamCreditTransaction.amount_left), 0.0),
+            )
+            .where(
+                TeamCreditTransaction.team_id.in_(team_ids),
+                TeamCreditTransaction.is_active == True,  # noqa: E712
+                TeamCreditTransaction.status == CreditTransactionStatus.completed,
+            )
+            .group_by(TeamCreditTransaction.team_id)
+        )
+    ).all()
+    balances = {r[0]: float(r[1]) for r in balance_rows}
+
+    result: dict[uuid.UUID, TeamExtraContext] = {}
+    for membership, team in rows:
+        if team.status != "active":
+            result[membership.user_id] = TeamExtraContext(team_id=team.id, available=0.0)
+            continue
+        member_cap = (
+            membership.extra_credits_cap_override
+            if membership.extra_credits_cap_override is not None
+            else (team.extra_credits_member_default_cap or 0.0)
+        )
+        team_cap = team.extra_credits_monthly_cap or 0.0
+        available = max(
+            0.0,
+            min(
+                member_cap - member_spent.get(membership.user_id, 0.0),
+                team_cap - team_spent.get(team.id, 0.0),
+                balances.get(team.id, 0.0),
+            ),
+        )
+        result[membership.user_id] = TeamExtraContext(team_id=team.id, available=available)
+    return result
 
 
 async def open_windows(db: AsyncSession, user_id: uuid.UUID, now: datetime | None = None) -> None:
@@ -227,7 +396,12 @@ async def get_allowance_state(
     usage_weekly = await _usage_since(db, user_id, window_weekly.started_at) if window_weekly else 0.0
     prepaid = await _prepaid_balance(db, user_id)
 
-    source = compute_source(tier, usage_5h, usage_weekly, prepaid)
+    ctx = await get_team_extra_context(db, user_id, now)
+    if ctx is not None:
+        # Members never spend personal prepaid — the team extra path funds overflow.
+        source = compute_source(tier, usage_5h, usage_weekly, 0.0, team_extra_available=ctx.available)
+    else:
+        source = compute_source(tier, usage_5h, usage_weekly, prepaid)
 
     return AllowanceState(
         allowed=source != "blocked",

--- a/src/services/payments/manager.py
+++ b/src/services/payments/manager.py
@@ -34,6 +34,7 @@ from src.services.payments.base import (
     PaymentProvider,
     UnsupportedCapability,
 )
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
 from src.subscription_tiers import (
     DEFAULT_CURRENCY,
     DEFAULT_TIER,
@@ -64,6 +65,8 @@ class PaymentManager:
         stmt = select(PlanSubscription).where(
             PlanSubscription.user_id == user_id,
             PlanSubscription.status.in_(["pending", "active", "overdue"]),
+            # Team seats are managed by the team service, never by personal payment flows.
+            PlanSubscription.provider != TEAM_CREDITS_PROVIDER,
         )
         if lock:
             stmt = stmt.with_for_update()
@@ -510,6 +513,8 @@ class PaymentManager:
                 PlanSubscription.status.in_(["active", "overdue"]),
                 PlanSubscription.cancel_at_period_end == True,  # noqa: E712
                 PlanSubscription.current_period_end <= pre_cutoff,
+                # Team seats are managed by the team service, never by personal payment flows.
+                PlanSubscription.provider != TEAM_CREDITS_PROVIDER,
             )
             .with_for_update()
         )
@@ -524,6 +529,8 @@ class PaymentManager:
                 PlanSubscription.current_period_end < cutoff,
                 (PlanSubscription.cancel_at_period_end == True)  # noqa: E712
                 | (PlanSubscription.is_trial == True),  # noqa: E712
+                # Team seats are managed by the team service, never by personal payment flows.
+                PlanSubscription.provider != TEAM_CREDITS_PROVIDER,
             )
             .with_for_update()
         )

--- a/src/services/payments/manager.py
+++ b/src/services/payments/manager.py
@@ -214,9 +214,16 @@ class PaymentManager:
             else:
                 logger.info(f"Top-up {tx.external_reference} already completed, skipping")
         elif event.type == PaymentEventType.order_failed:
-            tx.status = CreditTransactionStatus.error
-            tx.is_active = False
-            tx.amount_left = 0
+            # An out-of-order failed event after completion must not erase a spendable
+            # balance — only fail a row that hasn't already been credited.
+            if tx.status != CreditTransactionStatus.completed:
+                tx.status = CreditTransactionStatus.error
+                tx.is_active = False
+                tx.amount_left = 0
+            else:
+                logger.warning(
+                    f"Ignoring out-of-order order_failed for completed top-up {tx.external_reference}"
+                )
         await self.db.flush()
         return True
 
@@ -240,9 +247,16 @@ class PaymentManager:
                 tx.status = CreditTransactionStatus.completed
                 logger.info(f"Team top-up {tx.external_reference} completed ({tx.amount} credits)")
         elif event.type == PaymentEventType.order_failed:
-            tx.status = CreditTransactionStatus.error
-            tx.is_active = False
-            tx.amount_left = 0
+            # An out-of-order failed event after completion must not erase a spendable
+            # balance — only fail a row that hasn't already been credited.
+            if tx.status != CreditTransactionStatus.completed:
+                tx.status = CreditTransactionStatus.error
+                tx.is_active = False
+                tx.amount_left = 0
+            else:
+                logger.warning(
+                    f"Ignoring out-of-order order_failed for completed top-up {tx.external_reference}"
+                )
         await self.db.flush()
         return True
 

--- a/src/services/payments/manager.py
+++ b/src/services/payments/manager.py
@@ -24,6 +24,8 @@ from src.interfaces.credits import CreditTransactionProvider, CreditTransactionS
 from src.models.credit_transaction import CreditTransaction
 from src.models.plan_subscription import PlanSubscription
 from src.models.plan_subscription_event import PlanSubscriptionEvent
+from src.models.team import Team
+from src.models.team_credit_transaction import TeamCreditTransaction
 from src.models.user import User
 from src.services.geo import vat_rate_for_currency
 from src.services.payments.base import (
@@ -35,6 +37,7 @@ from src.services.payments.base import (
     UnsupportedCapability,
 )
 from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+from src.services.team_credit import TeamCreditService
 from src.subscription_tiers import (
     DEFAULT_CURRENCY,
     DEFAULT_TIER,
@@ -49,6 +52,7 @@ logger = logging.getLogger(__name__)
 # A top-up credit transaction is keyed by this hash so webhook replays dedup and
 # the pending row created at checkout time can be completed on confirmation.
 TOPUP_EXT_REF_PREFIX = "topup:"
+TEAM_TOPUP_EXT_REF_PREFIX = "topup:team:"
 
 
 def _topup_external_ref(provider_id: str, order_id: str) -> str:
@@ -149,6 +153,46 @@ class PaymentManager:
             await self.db.flush()
         return result
 
+    async def start_team_topup(
+        self,
+        team: Team,
+        admin_email: str | None,
+        redirect_url: str,
+        *,
+        usd_credits: float,
+    ) -> CheckoutResult:
+        """Open a hosted checkout that funds a TEAM balance (USD only in v1).
+
+        Same shape as ``start_topup`` but the pending row lands in
+        ``team_credit_transactions`` — ``_settle_topup`` completes it from there.
+        """
+        if not self.provider.supports(PaymentCapability.topup):
+            raise UnsupportedCapability(f"{self.provider.id} does not support top-ups")
+        if usd_credits <= 0:
+            raise ValueError("Top-up credit amount must be positive")
+        if team.status != "active":
+            raise ValueError("Team is suspended")
+
+        result = await self.provider.create_topup(
+            amount=usd_credits,
+            currency="USD",
+            redirect_url=redirect_url,
+            user_email=admin_email,
+            metadata={"ext_ref": f"{TEAM_TOPUP_EXT_REF_PREFIX}{team.id}"},
+            vat_rate=vat_rate_for_currency("USD"),
+            item_name=f"LibertAI team credits (${usd_credits:g}) — {team.name}",
+        )
+        if result.order_id:
+            await TeamCreditService.add_credits(
+                self.db,
+                team.id,
+                usd_credits,
+                CreditTransactionProvider.revolut,
+                external_reference=_topup_external_ref(self.provider.id, result.order_id),
+                status=CreditTransactionStatus.pending,
+            )
+        return result
+
     async def _settle_topup(self, event: PaymentEvent) -> bool:
         """Complete/fail a pending top-up. Returns True if this event was a top-up."""
         if not event.order_id:
@@ -161,7 +205,7 @@ class PaymentManager:
             )
         ).scalar_one_or_none()
         if tx is None:
-            return False  # not a (locally-recorded) top-up — let the subscription path try
+            return await self._settle_team_topup(event)
 
         if event.type == PaymentEventType.order_completed:
             if tx.status != CreditTransactionStatus.completed:
@@ -169,6 +213,32 @@ class PaymentManager:
                 logger.info(f"Top-up {tx.external_reference} completed ({tx.amount} credits)")
             else:
                 logger.info(f"Top-up {tx.external_reference} already completed, skipping")
+        elif event.type == PaymentEventType.order_failed:
+            tx.status = CreditTransactionStatus.error
+            tx.is_active = False
+            tx.amount_left = 0
+        await self.db.flush()
+        return True
+
+    async def _settle_team_topup(self, event: PaymentEvent) -> bool:
+        if not event.order_id:
+            return False
+        tx = (
+            await self.db.execute(
+                select(TeamCreditTransaction)
+                .where(
+                    TeamCreditTransaction.external_reference
+                    == _topup_external_ref(event.provider, event.order_id)
+                )
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if tx is None:
+            return False
+        if event.type == PaymentEventType.order_completed:
+            if tx.status != CreditTransactionStatus.completed:
+                tx.status = CreditTransactionStatus.completed
+                logger.info(f"Team top-up {tx.external_reference} completed ({tx.amount} credits)")
         elif event.type == PaymentEventType.order_failed:
             tx.status = CreditTransactionStatus.error
             tx.is_active = False

--- a/src/services/payments/team_seat_subscription.py
+++ b/src/services/payments/team_seat_subscription.py
@@ -13,6 +13,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.plan_subscription import PlanSubscription
@@ -134,7 +135,12 @@ class TeamSeatService:
             seat_price_snapshot=price,
         )
         db.add(seat)
-        await db.flush()
+        try:
+            await db.flush()
+        except IntegrityError:
+            # Concurrent assign/personal-subscribe slipped past the checks above; the
+            # partial unique index (one live sub per user) is the source of truth.
+            raise ValueError("Member already has an active subscription or seat")
         _log(db, seat, "activated", {"team_id": str(team.id), "prorated_charge": charge})
         return seat
 
@@ -165,13 +171,26 @@ class TeamSeatService:
                     db, team.id, "seat_charge_prorated", charge,
                     {"user_id": str(user_id), "tier": new_tier, "upgrade_from": seat.tier},
                 )
-            _log(db, seat, "upgraded", {"from": seat.tier, "to": new_tier, "prorated_charge": charge})
+            # A tier change expresses intent to keep the seat: clear any prior cancel
+            # so an admin who cancelled then upgraded doesn't still lose the seat at
+            # month end (mirrors personal request_downgrade paid->paid semantics).
+            reactivated = seat.cancel_at_period_end
+            _log(
+                db,
+                seat,
+                "upgraded",
+                {"from": seat.tier, "to": new_tier, "prorated_charge": charge, "reactivated": reactivated},
+            )
             seat.tier = new_tier
             seat.pending_tier = None
             seat.seat_price_snapshot = new_price
+            seat.cancel_at_period_end = False
         elif is_downgrade(seat.tier, new_tier):
+            # Downgrade to a still-paid tier also keeps the seat alive — supersede any cancel.
+            reactivated = seat.cancel_at_period_end
             seat.pending_tier = new_tier
-            _log(db, seat, "downgrade_requested", {"new_tier": new_tier})
+            seat.cancel_at_period_end = False
+            _log(db, seat, "downgrade_requested", {"new_tier": new_tier, "reactivated": reactivated})
         else:
             raise ValueError("Seat is already on this tier")
         await db.flush()
@@ -191,7 +210,7 @@ class TeamSeatService:
     async def suspend_team(db: AsyncSession, team: Team) -> None:
         """Suspension is mechanical: seats are expired NOW, so entitlement (which
         reads active subs only) stops granting the tier without any team join."""
-        team.status = "suspended"
+        # Lock seats before touching the team row — process_renewals locks in the same order (seats -> team).
         seats = (
             await db.execute(
                 select(PlanSubscription)
@@ -203,6 +222,7 @@ class TeamSeatService:
                 .with_for_update()
             )
         ).scalars().all()
+        team.status = "suspended"
         for seat in seats:
             seat.status = "expired"
             _log(db, seat, "team_suspended")

--- a/src/services/payments/team_seat_subscription.py
+++ b/src/services/payments/team_seat_subscription.py
@@ -1,0 +1,3 @@
+"""Team seat subscriptions: PlanSubscription rows paid from the team balance."""
+
+TEAM_CREDITS_PROVIDER = "team_credits"

--- a/src/services/payments/team_seat_subscription.py
+++ b/src/services/payments/team_seat_subscription.py
@@ -21,7 +21,7 @@ from src.models.team import Team
 from src.models.team_membership import ROLE_ADMIN, TeamMembership
 from src.models.user import User
 from src.services.team_credit import TeamCreditService
-from src.subscription_tiers import DEFAULT_TIER, PAID_TIERS, is_downgrade, is_upgrade
+from src.subscription_tiers import DEFAULT_TIER, PAID_TIERS, get_tier, is_downgrade, is_upgrade
 from src.utils.email import send_email
 from src.utils.logger import setup_logger
 
@@ -41,6 +41,29 @@ def prorated_price(price: float, now: datetime) -> float:
     days_in_month = calendar.monthrange(now.year, now.month)[1]
     remaining_days = days_in_month - now.day + 1
     return round(price * remaining_days / days_in_month, 2)
+
+
+def _resolve_renewal_price(team: Team, target: str, seat: PlanSubscription) -> float:
+    """Seat price for renewal, tolerant of a tier dropped from the team's price map.
+
+    A non-empty ``seat_prices`` that lacks ``target`` would otherwise raise and wedge
+    the whole team's renewal every hour forever. Fall back to the seat's own snapshot
+    (what it last renewed at) or, failing that, the tier list price, and warn."""
+    from src.services.teams import TeamService
+
+    try:
+        return TeamService.seat_price(team, target)
+    except ValueError:
+        fallback = (
+            seat.seat_price_snapshot
+            if seat.seat_price_snapshot is not None
+            else get_tier(target).price_cents / 100
+        )
+        logger.warning(
+            f"Tier {target!r} missing from team {team.id} seat_prices; renewing seat "
+            f"{seat.id} at fallback price {fallback}"
+        )
+        return fallback
 
 
 def _log(db: AsyncSession, sub: PlanSubscription, event_type: str, metadata: dict | None = None) -> None:
@@ -195,8 +218,6 @@ class TeamSeatService:
         partial/priority charging). Returns (processed count, lapse notices) —
         the caller commits, then emails the notices (never inside the txn).
         """
-        from src.services.teams import TeamService
-
         now = now or datetime.now()
         due = (
             await db.execute(
@@ -244,7 +265,7 @@ class TeamSeatService:
                         continue
 
                     total = round(
-                        sum(TeamService.seat_price(team, s.pending_tier or s.tier) for s in renewing), 2
+                        sum(_resolve_renewal_price(team, s.pending_tier or s.tier, s) for s in renewing), 2
                     )
                     if total > 0 and not await TeamCreditService.use_credits(db, team.id, total):
                         for seat in renewing:
@@ -268,7 +289,7 @@ class TeamSeatService:
                             start = period_start
                         seat.tier = target
                         seat.pending_tier = None
-                        seat.seat_price_snapshot = TeamService.seat_price(team, target)
+                        seat.seat_price_snapshot = _resolve_renewal_price(team, target, seat)
                         seat.current_period_start = start
                         _, seat.current_period_end = month_bounds(start)
                         _log(db, seat, "renewed")

--- a/src/services/payments/team_seat_subscription.py
+++ b/src/services/payments/team_seat_subscription.py
@@ -1,3 +1,313 @@
-"""Team seat subscriptions: PlanSubscription rows paid from the team balance."""
+"""Team seat subscriptions: PlanSubscription rows paid from the team balance.
+
+Calendar-month aligned (naive ``datetime.now()``, codebase convention): a seat
+assigned mid-month is charged ``price * remaining_days / days_in_month``
+(remaining includes today) and every seat renews on the 1st via
+``process_renewals`` — one aggregate debit per team, all-or-nothing.
+"""
+
+from __future__ import annotations
+
+import calendar
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.plan_subscription import PlanSubscription
+from src.models.plan_subscription_event import PlanSubscriptionEvent
+from src.models.team import Team
+from src.models.team_membership import ROLE_ADMIN, TeamMembership
+from src.models.user import User
+from src.services.team_credit import TeamCreditService
+from src.subscription_tiers import DEFAULT_TIER, PAID_TIERS, is_downgrade, is_upgrade
+from src.utils.email import send_email
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
 
 TEAM_CREDITS_PROVIDER = "team_credits"
+
+
+def month_bounds(now: datetime) -> tuple[datetime, datetime]:
+    start = datetime(now.year, now.month, 1)
+    end = datetime(now.year + (now.month == 12), now.month % 12 + 1, 1)
+    return start, end
+
+
+def prorated_price(price: float, now: datetime) -> float:
+    """Charge for the rest of the month, today included (1st = full price)."""
+    days_in_month = calendar.monthrange(now.year, now.month)[1]
+    remaining_days = days_in_month - now.day + 1
+    return round(price * remaining_days / days_in_month, 2)
+
+
+def _log(db: AsyncSession, sub: PlanSubscription, event_type: str, metadata: dict | None = None) -> None:
+    db.add(
+        PlanSubscriptionEvent(
+            subscription_id=sub.id, event_type=event_type, provider_event_id=None, metadata_json=metadata
+        )
+    )
+
+
+async def _active_seat(db: AsyncSession, user_id: uuid.UUID) -> PlanSubscription | None:
+    return (
+        await db.execute(
+            select(PlanSubscription)
+            .where(
+                PlanSubscription.user_id == user_id,
+                PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                PlanSubscription.status == "active",
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+
+
+class TeamSeatService:
+    @staticmethod
+    async def assign_seat(
+        db: AsyncSession, team: Team, user_id: uuid.UUID, tier: str, now: datetime | None = None
+    ) -> PlanSubscription:
+        from src.services.teams import TeamService  # local import: teams.py imports our constant
+
+        now = now or datetime.now()
+        if team.status != "active":
+            raise ValueError("Team is suspended")
+        if tier not in PAID_TIERS:
+            raise ValueError(f"Unknown or non-paid tier: {tier}")
+        membership = (
+            await db.execute(
+                select(TeamMembership).where(
+                    TeamMembership.team_id == team.id, TeamMembership.user_id == user_id
+                )
+            )
+        ).scalar_one_or_none()
+        if membership is None:
+            raise ValueError("User is not a member of this team")
+        if await _active_seat(db, user_id) is not None:
+            raise ValueError("Member already has a seat")
+
+        price = TeamService.seat_price(team, tier)
+        charge = prorated_price(price, now)
+        if not await TeamCreditService.use_credits(db, team.id, charge):
+            raise ValueError("Insufficient team balance — top up first")
+        await TeamCreditService.log(
+            db, team.id, "seat_charge_prorated", charge,
+            {"user_id": str(user_id), "tier": tier, "monthly_price": price},
+        )
+
+        _, period_end = month_bounds(now)
+        seat = PlanSubscription(
+            user_id=user_id,
+            tier=tier,
+            provider=TEAM_CREDITS_PROVIDER,
+            status="active",
+            currency="USD",
+            current_period_start=now,
+            current_period_end=period_end,
+            team_id=team.id,
+            seat_price_snapshot=price,
+        )
+        db.add(seat)
+        await db.flush()
+        _log(db, seat, "activated", {"team_id": str(team.id), "prorated_charge": charge})
+        return seat
+
+    @staticmethod
+    async def change_tier(
+        db: AsyncSession, team: Team, user_id: uuid.UUID, new_tier: str, now: datetime | None = None
+    ) -> PlanSubscription:
+        from src.services.teams import TeamService
+
+        now = now or datetime.now()
+        if team.status != "active":
+            raise ValueError("Team is suspended")
+        if new_tier not in PAID_TIERS:
+            raise ValueError(f"Unknown or non-paid tier: {new_tier}")
+        seat = await _active_seat(db, user_id)
+        if seat is None or seat.team_id != team.id:
+            raise ValueError("Member has no active seat")
+
+        if is_upgrade(seat.tier, new_tier):
+            # Immediate: prorated difference against the snapshot base for this month.
+            new_price = TeamService.seat_price(team, new_tier)
+            old_price = seat.seat_price_snapshot or TeamService.seat_price(team, seat.tier)
+            charge = max(0.0, prorated_price(new_price - old_price, now))
+            if charge > 0 and not await TeamCreditService.use_credits(db, team.id, charge):
+                raise ValueError("Insufficient team balance — top up first")
+            if charge > 0:
+                await TeamCreditService.log(
+                    db, team.id, "seat_charge_prorated", charge,
+                    {"user_id": str(user_id), "tier": new_tier, "upgrade_from": seat.tier},
+                )
+            _log(db, seat, "upgraded", {"from": seat.tier, "to": new_tier, "prorated_charge": charge})
+            seat.tier = new_tier
+            seat.pending_tier = None
+            seat.seat_price_snapshot = new_price
+        elif is_downgrade(seat.tier, new_tier):
+            seat.pending_tier = new_tier
+            _log(db, seat, "downgrade_requested", {"new_tier": new_tier})
+        else:
+            raise ValueError("Seat is already on this tier")
+        await db.flush()
+        return seat
+
+    @staticmethod
+    async def cancel_seat(db: AsyncSession, team: Team, user_id: uuid.UUID) -> None:
+        seat = await _active_seat(db, user_id)
+        if seat is None or seat.team_id != team.id:
+            raise ValueError("Member has no active seat")
+        seat.cancel_at_period_end = True
+        seat.pending_tier = DEFAULT_TIER
+        _log(db, seat, "cancel_requested")
+        await db.flush()
+
+    @staticmethod
+    async def suspend_team(db: AsyncSession, team: Team) -> None:
+        """Suspension is mechanical: seats are expired NOW, so entitlement (which
+        reads active subs only) stops granting the tier without any team join."""
+        team.status = "suspended"
+        seats = (
+            await db.execute(
+                select(PlanSubscription)
+                .where(
+                    PlanSubscription.team_id == team.id,
+                    PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                    PlanSubscription.status == "active",
+                )
+                .with_for_update()
+            )
+        ).scalars().all()
+        for seat in seats:
+            seat.status = "expired"
+            _log(db, seat, "team_suspended")
+        await db.flush()
+
+    @staticmethod
+    async def process_renewals(
+        db: AsyncSession, now: datetime | None = None
+    ) -> tuple[int, list[dict]]:
+        """Renew every team's due seats with ONE aggregate debit per team.
+
+        All-or-nothing per team: on shortfall ALL renewing seats expire (no
+        partial/priority charging). Returns (processed count, lapse notices) —
+        the caller commits, then emails the notices (never inside the txn).
+        """
+        from src.services.teams import TeamService
+
+        now = now or datetime.now()
+        due = (
+            await db.execute(
+                select(PlanSubscription)
+                .where(
+                    PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                    PlanSubscription.status == "active",
+                    PlanSubscription.current_period_end <= now,
+                )
+                .order_by(PlanSubscription.team_id)
+                .with_for_update()
+            )
+        ).scalars().all()
+
+        by_team: dict[uuid.UUID, list[PlanSubscription]] = {}
+        for seat in due:
+            if seat.team_id is None:  # defensive: team_credits seats always set this on creation
+                continue
+            by_team.setdefault(seat.team_id, []).append(seat)
+
+        count = 0
+        notices: list[dict] = []
+        for team_id, seats in by_team.items():
+            # One bad team must not block the whole batch (same idiom as
+            # CreditSubscriptionService.process_renewals).
+            try:
+                async with db.begin_nested():
+                    count += len(seats)
+                    team = (
+                        await db.execute(select(Team).where(Team.id == team_id).with_for_update())
+                    ).scalar_one()
+
+                    renewing = []
+                    for seat in seats:
+                        if (
+                            team.status != "active"
+                            or seat.cancel_at_period_end
+                            or seat.pending_tier == DEFAULT_TIER
+                        ):
+                            seat.status = "expired"
+                            _log(db, seat, "expired")
+                        else:
+                            renewing.append(seat)
+                    if not renewing:
+                        continue
+
+                    total = round(
+                        sum(TeamService.seat_price(team, s.pending_tier or s.tier) for s in renewing), 2
+                    )
+                    if total > 0 and not await TeamCreditService.use_credits(db, team.id, total):
+                        for seat in renewing:
+                            seat.status = "expired"
+                            _log(db, seat, "expired_insufficient_team_balance")
+                        notices.append(await _lapse_notice(db, team, total))
+                        continue
+
+                    if total > 0:
+                        await TeamCreditService.log(
+                            db, team.id, "monthly_renewal", total, {"seats": len(renewing)}
+                        )
+                    period_start, period_end = month_bounds(now)
+                    for seat in renewing:
+                        target = seat.pending_tier or seat.tier
+                        # Anchor at the old period end (the 1st); if the cron was down
+                        # for over a cycle, re-anchor at the current month instead of
+                        # back-billing elapsed months.
+                        start = seat.current_period_end or period_start
+                        if start < period_start:
+                            start = period_start
+                        seat.tier = target
+                        seat.pending_tier = None
+                        seat.seat_price_snapshot = TeamService.seat_price(team, target)
+                        seat.current_period_start = start
+                        _, seat.current_period_end = month_bounds(start)
+                        _log(db, seat, "renewed")
+            except Exception:
+                logger.error(f"Failed to process seat renewals for team {team_id}", exc_info=True)
+
+        await db.flush()
+        return count, notices
+
+
+async def _lapse_notice(db: AsyncSession, team: Team, total: float) -> dict:
+    admin_emails = (
+        await db.execute(
+            select(User.email)
+            .join(TeamMembership, TeamMembership.user_id == User.id)
+            .where(
+                TeamMembership.team_id == team.id,
+                TeamMembership.role == ROLE_ADMIN,
+                User.email.isnot(None),
+            )
+        )
+    ).scalars().all()
+    return {
+        "team_id": team.id,
+        "team_name": team.name,
+        "admin_emails": list(admin_emails),
+        "total": total,
+    }
+
+
+async def send_lapse_emails(notices: list[dict]) -> None:
+    for notice in notices:
+        await send_email(
+            notice["admin_emails"],
+            f"[LibertAI] {notice['team_name']}: seat renewal failed",
+            (
+                f"<h2>Seat renewal failed for {notice['team_name']}</h2>"
+                f"<p>The monthly renewal (${notice['total']:g}) could not be charged to your team "
+                "balance, so all seats have been deactivated and members fell back to the free tier.</p>"
+                "<p>Top up your team balance in the console, then re-assign the seats.</p>"
+            ),
+        )

--- a/src/services/team_credit.py
+++ b/src/services/team_credit.py
@@ -1,0 +1,116 @@
+"""Team credit balance: top-ups drained in place, plus the debit ledger.
+
+Mirrors ``CreditService``'s draining algorithm against the team-scoped table.
+All methods run on the caller's session and only flush — the caller commits.
+"""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.models.team_credit_transaction import TeamCreditTransaction
+from src.models.team_ledger_entry import TeamLedgerEntry
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+class TeamCreditService:
+    @staticmethod
+    async def get_balance(db: AsyncSession, team_id: uuid.UUID) -> float:
+        result = await db.execute(
+            select(func.coalesce(func.sum(TeamCreditTransaction.amount_left), 0.0)).where(
+                TeamCreditTransaction.team_id == team_id,
+                TeamCreditTransaction.is_active == True,  # noqa: E712
+                TeamCreditTransaction.status == CreditTransactionStatus.completed,
+            )
+        )
+        return float(result.scalar() or 0.0)
+
+    @staticmethod
+    async def add_credits(
+        db: AsyncSession,
+        team_id: uuid.UUID,
+        amount: float,
+        provider: CreditTransactionProvider,
+        external_reference: str | None = None,
+        status: CreditTransactionStatus = CreditTransactionStatus.completed,
+    ) -> TeamCreditTransaction | None:
+        """Record a team top-up. Returns None if ``external_reference`` was already processed."""
+        if external_reference:
+            existing = (
+                await db.execute(
+                    select(TeamCreditTransaction.id).where(
+                        TeamCreditTransaction.external_reference == external_reference
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing:
+                logger.warning(f"Team transaction {external_reference} already processed, skipping")
+                return None
+        tx = TeamCreditTransaction(
+            team_id=team_id,
+            amount=amount,
+            amount_left=amount,
+            provider=provider,
+            external_reference=external_reference,
+            status=status,
+        )
+        db.add(tx)
+        await db.flush()
+        return tx
+
+    @staticmethod
+    async def use_credits(
+        db: AsyncSession, team_id: uuid.UUID, amount: float, allow_partial: bool = False
+    ) -> bool:
+        """Deduct from the team's completed transactions, oldest first, rows locked.
+
+        Returns True if the full amount was deducted; on shortfall deducts nothing
+        unless ``allow_partial`` (then drains what's available and returns False).
+        """
+        result = await db.execute(
+            select(TeamCreditTransaction)
+            .where(
+                TeamCreditTransaction.team_id == team_id,
+                TeamCreditTransaction.is_active == True,  # noqa: E712
+                TeamCreditTransaction.status == CreditTransactionStatus.completed,
+            )
+            .order_by(TeamCreditTransaction.created_at.asc())
+            .with_for_update()
+        )
+        transactions = result.scalars().all()
+
+        available = sum(tx.amount_left for tx in transactions if tx.amount_left > 0)
+        fully_deductible = available >= amount
+        if not fully_deductible:
+            logger.warning(
+                f"Insufficient team credits for team {team_id}: requested {amount}, missing {amount - available}"
+            )
+            if not allow_partial:
+                return False
+
+        remaining = amount
+        for tx in transactions:
+            if tx.amount_left <= 0:
+                continue
+            take = min(tx.amount_left, remaining)
+            tx.amount_left -= take
+            remaining -= take
+            if remaining <= 0:
+                break
+        await db.flush()
+        return fully_deductible
+
+    @staticmethod
+    async def log(
+        db: AsyncSession,
+        team_id: uuid.UUID,
+        entry_type: str,
+        amount: float,
+        metadata: dict | None = None,
+    ) -> None:
+        db.add(TeamLedgerEntry(team_id=team_id, entry_type=entry_type, amount=amount, metadata_json=metadata))
+        await db.flush()

--- a/src/services/teams.py
+++ b/src/services/teams.py
@@ -222,6 +222,8 @@ class TeamService:
             raise ValueError("Invalid or expired invite")
         if not user.email or user.email.strip().lower() != invite.email:
             raise ValueError("This invite was sent to a different email address")
+        if not user.email_verified:
+            raise ValueError("Verify your email address before accepting this invite")
         if await TeamService.get_membership(db, user.id) is not None:
             raise ValueError("You are already in a team")
         live_sub = (

--- a/src/services/teams.py
+++ b/src/services/teams.py
@@ -63,6 +63,14 @@ async def expire_seat_now(
 
 class TeamService:
     @staticmethod
+    def _validate_seat_prices(seat_prices: dict[str, float]) -> None:
+        for tier, price in seat_prices.items():
+            if tier not in PAID_TIERS:
+                raise ValueError(f"Unknown tier in seat_prices: {tier}")
+            if not isinstance(price, (int, float)) or price <= 0:
+                raise ValueError(f"Seat price for {tier} must be positive")
+
+    @staticmethod
     async def create_team(
         db: AsyncSession,
         name: str,
@@ -71,11 +79,7 @@ class TeamService:
         extra_credits_member_default_cap: float | None = None,
     ) -> Team:
         seat_prices = seat_prices or {}
-        for tier, price in seat_prices.items():
-            if tier not in PAID_TIERS:
-                raise ValueError(f"Unknown tier in seat_prices: {tier}")
-            if not isinstance(price, (int, float)) or price <= 0:
-                raise ValueError(f"Seat price for {tier} must be positive")
+        TeamService._validate_seat_prices(seat_prices)
         team = Team(name=name)
         team.seat_prices = seat_prices
         team.extra_credits_monthly_cap = extra_credits_monthly_cap

--- a/src/services/teams.py
+++ b/src/services/teams.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models.plan_subscription import PlanSubscription
 from src.models.plan_subscription_event import PlanSubscriptionEvent
 from src.models.team import Team
-from src.models.team_membership import ROLE_ADMIN, TeamMembership
+from src.models.team_membership import ROLE_ADMIN, ROLE_MEMBER, TeamMembership
 from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
 from src.subscription_tiers import PAID_TIERS, get_tier
 from src.utils.logger import setup_logger
@@ -118,7 +118,9 @@ class TeamService:
     async def set_role(
         db: AsyncSession, team_id: uuid.UUID, actor_id: uuid.UUID, target_user_id: uuid.UUID, role: str
     ) -> None:
-        if role not in (ROLE_ADMIN, "member"):
+        # Defense-in-depth: routes also gate on admin, but the service must not trust callers.
+        await TeamService.require_membership(db, team_id, actor_id, admin=True)
+        if role not in (ROLE_ADMIN, ROLE_MEMBER):
             raise ValueError(f"Unknown role: {role}")
         target = await TeamService.require_membership(db, team_id, target_user_id)
         if role != ROLE_ADMIN:

--- a/src/services/teams.py
+++ b/src/services/teams.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime, timedelta
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.plan_subscription import ACTIVE_STATUSES, PlanSubscription
@@ -248,5 +249,10 @@ class TeamService:
         invite.status = "accepted"
         membership = TeamMembership(team_id=invite.team_id, user_id=user.id, role=invite.role)
         db.add(membership)
-        await db.flush()
+        try:
+            await db.flush()
+        except IntegrityError:
+            # Concurrent accept slipped past the get_membership check above; the unique
+            # constraint on user membership is the source of truth.
+            raise ValueError("You are already in a team")
         return membership

--- a/src/services/teams.py
+++ b/src/services/teams.py
@@ -4,20 +4,32 @@ Seat billing lives in ``payments/team_seat_subscription.py``; invites in this
 module too (Task 5). All methods flush only — the caller commits.
 """
 
+import hashlib
+import secrets
 import uuid
+from datetime import datetime, timedelta
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models.plan_subscription import PlanSubscription
+from src.models.plan_subscription import ACTIVE_STATUSES, PlanSubscription
 from src.models.plan_subscription_event import PlanSubscriptionEvent
 from src.models.team import Team
+from src.models.team_invite import TeamInvite
 from src.models.team_membership import ROLE_ADMIN, ROLE_MEMBER, TeamMembership
+from src.models.user import User
+from src.services.credit import CreditService
 from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
 from src.subscription_tiers import PAID_TIERS, get_tier
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
+
+_INVITE_TTL_DAYS = 7
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
 
 
 async def expire_seat_now(
@@ -154,3 +166,81 @@ class TeamService:
         await expire_seat_now(db, user_id, "member_left", metadata={"removed_by": str(user_id)})
         await db.delete(membership)
         await db.flush()
+
+    @staticmethod
+    async def create_invite(
+        db: AsyncSession, team_id: uuid.UUID, email: str, role: str, invited_by: uuid.UUID | str
+    ) -> tuple[TeamInvite, str]:
+        if role not in (ROLE_ADMIN, ROLE_MEMBER):
+            raise ValueError(f"Unknown role: {role}")
+        email = email.strip().lower()
+        # A fresh invite supersedes any older pending one for the same address.
+        older = (
+            await db.execute(
+                select(TeamInvite).where(
+                    TeamInvite.team_id == team_id,
+                    TeamInvite.email == email,
+                    TeamInvite.status == "pending",
+                )
+            )
+        ).scalars().all()
+        for invite in older:
+            invite.status = "revoked"
+        token = secrets.token_urlsafe(32)
+        invite = TeamInvite(
+            team_id=team_id,
+            email=email,
+            role=role,
+            token_hash=_hash_token(token),
+            expires_at=datetime.now() + timedelta(days=_INVITE_TTL_DAYS),
+        )
+        db.add(invite)
+        await db.flush()
+        return invite, token
+
+    @staticmethod
+    async def revoke_invite(db: AsyncSession, team_id: uuid.UUID, invite_id: uuid.UUID) -> None:
+        invite = (
+            await db.execute(
+                select(TeamInvite).where(TeamInvite.id == invite_id, TeamInvite.team_id == team_id)
+            )
+        ).scalar_one_or_none()
+        if invite is None or invite.status != "pending":
+            raise ValueError("No pending invite to revoke")
+        invite.status = "revoked"
+        await db.flush()
+
+    @staticmethod
+    async def accept_invite(db: AsyncSession, token: str, user: User) -> TeamMembership:
+        """Join guard: verified matching email, no live personal sub, zero balance, no team."""
+        invite = (
+            await db.execute(
+                select(TeamInvite).where(TeamInvite.token_hash == _hash_token(token)).with_for_update()
+            )
+        ).scalar_one_or_none()
+        if invite is None or invite.status != "pending" or invite.expires_at < datetime.now():
+            raise ValueError("Invalid or expired invite")
+        if not user.email or user.email.strip().lower() != invite.email:
+            raise ValueError("This invite was sent to a different email address")
+        if await TeamService.get_membership(db, user.id) is not None:
+            raise ValueError("You are already in a team")
+        live_sub = (
+            await db.execute(
+                select(PlanSubscription.id).where(
+                    PlanSubscription.user_id == user.id,
+                    PlanSubscription.status.in_(ACTIVE_STATUSES),
+                )
+            )
+        ).scalars().first()
+        if live_sub:
+            raise ValueError(
+                "You have an active personal subscription — cancel it and wait for it to end before joining"
+            )
+        if await CreditService.get_balance(user.id, db=db) > 0:
+            raise ValueError("Your personal credit balance must be empty before joining a team")
+
+        invite.status = "accepted"
+        membership = TeamMembership(team_id=invite.team_id, user_id=user.id, role=invite.role)
+        db.add(membership)
+        await db.flush()
+        return membership

--- a/src/services/teams.py
+++ b/src/services/teams.py
@@ -1,0 +1,154 @@
+"""Teams: creation (staff), membership, roles and the guards around them.
+
+Seat billing lives in ``payments/team_seat_subscription.py``; invites in this
+module too (Task 5). All methods flush only — the caller commits.
+"""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.plan_subscription import PlanSubscription
+from src.models.plan_subscription_event import PlanSubscriptionEvent
+from src.models.team import Team
+from src.models.team_membership import ROLE_ADMIN, TeamMembership
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+from src.subscription_tiers import PAID_TIERS, get_tier
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+async def expire_seat_now(
+    db: AsyncSession, user_id: uuid.UUID, reason: str, metadata: dict | None = None
+) -> None:
+    """Expire the user's active team seat immediately (removal/leave/suspension).
+
+    Remaining paid time is intentionally lost (spec: no refund to balance).
+    """
+    seat = (
+        await db.execute(
+            select(PlanSubscription)
+            .where(
+                PlanSubscription.user_id == user_id,
+                PlanSubscription.provider == TEAM_CREDITS_PROVIDER,
+                PlanSubscription.status == "active",
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if seat is None:
+        return
+    seat.status = "expired"
+    db.add(
+        PlanSubscriptionEvent(
+            subscription_id=seat.id, event_type=reason, provider_event_id=None, metadata_json=metadata
+        )
+    )
+    await db.flush()
+
+
+class TeamService:
+    @staticmethod
+    async def create_team(
+        db: AsyncSession,
+        name: str,
+        seat_prices: dict[str, float] | None = None,
+        extra_credits_monthly_cap: float | None = None,
+        extra_credits_member_default_cap: float | None = None,
+    ) -> Team:
+        seat_prices = seat_prices or {}
+        for tier, price in seat_prices.items():
+            if tier not in PAID_TIERS:
+                raise ValueError(f"Unknown tier in seat_prices: {tier}")
+            if not isinstance(price, (int, float)) or price <= 0:
+                raise ValueError(f"Seat price for {tier} must be positive")
+        team = Team(name=name)
+        team.seat_prices = seat_prices
+        team.extra_credits_monthly_cap = extra_credits_monthly_cap
+        team.extra_credits_member_default_cap = extra_credits_member_default_cap
+        db.add(team)
+        await db.flush()
+        return team
+
+    @staticmethod
+    def seat_price(team: Team, tier: str) -> float:
+        """Negotiated monthly USD price for a tier; list price when no deal is configured."""
+        if team.seat_prices:
+            price = team.seat_prices.get(tier)
+            if price is None:
+                raise ValueError(f"Tier {tier!r} is not sold to this team")
+            return float(price)
+        return get_tier(tier).price_cents / 100
+
+    @staticmethod
+    async def get_membership(db: AsyncSession, user_id: uuid.UUID) -> TeamMembership | None:
+        return (
+            await db.execute(select(TeamMembership).where(TeamMembership.user_id == user_id))
+        ).scalar_one_or_none()
+
+    @staticmethod
+    async def require_membership(
+        db: AsyncSession, team_id: uuid.UUID, user_id: uuid.UUID, admin: bool = False
+    ) -> TeamMembership:
+        membership = await TeamService.get_membership(db, user_id)
+        if membership is None or membership.team_id != team_id:
+            raise PermissionError("Not a member of this team")
+        if admin and membership.role != ROLE_ADMIN:
+            raise PermissionError("Requires team admin role")
+        return membership
+
+    @staticmethod
+    async def _admin_count(db: AsyncSession, team_id: uuid.UUID) -> int:
+        return (
+            await db.execute(
+                select(func.count()).where(
+                    TeamMembership.team_id == team_id, TeamMembership.role == ROLE_ADMIN
+                )
+            )
+        ).scalar_one()
+
+    @staticmethod
+    async def _guard_not_last_admin(db: AsyncSession, membership: TeamMembership) -> None:
+        if membership.role == ROLE_ADMIN and await TeamService._admin_count(db, membership.team_id) <= 1:
+            raise ValueError("Cannot remove or demote the last admin of a team")
+
+    @staticmethod
+    async def set_role(
+        db: AsyncSession, team_id: uuid.UUID, actor_id: uuid.UUID, target_user_id: uuid.UUID, role: str
+    ) -> None:
+        if role not in (ROLE_ADMIN, "member"):
+            raise ValueError(f"Unknown role: {role}")
+        target = await TeamService.require_membership(db, team_id, target_user_id)
+        if role != ROLE_ADMIN:
+            await TeamService._guard_not_last_admin(db, target)
+        target.role = role
+        await db.flush()
+
+    @staticmethod
+    async def remove_member(
+        db: AsyncSession, team_id: uuid.UUID, target_user_id: uuid.UUID, removed_by: uuid.UUID | str
+    ) -> None:
+        """Delete the membership and expire any seat immediately.
+
+        The remover is recorded in the seat event metadata because the
+        membership row (and its audit trail) is deleted here.
+        """
+        target = await TeamService.require_membership(db, team_id, target_user_id)
+        await TeamService._guard_not_last_admin(db, target)
+        await expire_seat_now(
+            db, target_user_id, "member_removed", metadata={"removed_by": str(removed_by)}
+        )
+        await db.delete(target)
+        await db.flush()
+
+    @staticmethod
+    async def leave(db: AsyncSession, user_id: uuid.UUID) -> None:
+        membership = await TeamService.get_membership(db, user_id)
+        if membership is None:
+            raise ValueError("Not a member of any team")
+        await TeamService._guard_not_last_admin(db, membership)
+        await expire_seat_now(db, user_id, "member_left", metadata={"removed_by": str(user_id)})
+        await db.delete(membership)
+        await db.flush()

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -1,0 +1,43 @@
+"""Minimal async SMTP sender for transactional mails (invites, seat-lapse notices).
+
+Mirrors the magic-link mailer's convention: with no SMTP_HOST configured (dev),
+log the mail instead of sending.
+"""
+
+import asyncio
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from src.config import config
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def _send_smtp(to: list[str], subject: str, html: str) -> None:
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = config.SMTP_FROM
+    msg["To"] = ", ".join(to)
+    msg.attach(MIMEText(html, "html"))
+    with smtplib.SMTP(config.SMTP_HOST, config.SMTP_PORT, timeout=15) as server:
+        if config.SMTP_USE_TLS:
+            server.starttls()
+        if config.SMTP_USER and config.SMTP_PASSWORD:
+            server.login(config.SMTP_USER, config.SMTP_PASSWORD)
+        server.sendmail(config.SMTP_FROM, to, msg.as_string())
+
+
+async def send_email(to: list[str], subject: str, html: str) -> None:
+    if not to:
+        return
+    if not config.SMTP_HOST:
+        logger.warning(f"[email mock] to={to} subject={subject!r}")
+        return
+    try:
+        await asyncio.to_thread(_send_smtp, to, subject, html)
+        logger.info(f"Email {subject!r} sent to {len(to)} recipient(s)")
+    except Exception as e:
+        # Transactional mail must never break the calling flow; log for ops.
+        logger.error(f"SMTP send failed for {to}: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,11 @@ import src.models.entitlement_window  # noqa: E402,F401
 import src.models.plan_subscription  # noqa: E402,F401
 import src.models.plan_subscription_event  # noqa: E402,F401
 import src.models.session  # noqa: E402,F401
+import src.models.team  # noqa: E402,F401
+import src.models.team_credit_transaction  # noqa: E402,F401
+import src.models.team_invite  # noqa: E402,F401
+import src.models.team_ledger_entry  # noqa: E402,F401
+import src.models.team_membership  # noqa: E402,F401
 import src.models.user  # noqa: E402,F401
 import src.models.wallet_challenge  # noqa: E402,F401
 import src.models.wallet_connection  # noqa: E402,F401

--- a/tests/test_team_credit.py
+++ b/tests/test_team_credit.py
@@ -1,0 +1,74 @@
+import pytest
+
+from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.models.team import Team
+from src.services.team_credit import TeamCreditService
+
+
+async def _team(db) -> Team:
+    team = Team(name="Acme")
+    db.add(team)
+    await db.flush()
+    return team
+
+
+@pytest.mark.asyncio
+async def test_balance_sums_only_completed_active(db):
+    team = await _team(db)
+    await TeamCreditService.add_credits(db, team.id, 100.0, CreditTransactionProvider.revolut)
+    await TeamCreditService.add_credits(
+        db, team.id, 50.0, CreditTransactionProvider.revolut,
+        external_reference="pending-1", status=CreditTransactionStatus.pending,
+    )
+    assert await TeamCreditService.get_balance(db, team.id) == 100.0
+
+
+@pytest.mark.asyncio
+async def test_add_credits_dedups_external_reference(db):
+    team = await _team(db)
+    first = await TeamCreditService.add_credits(
+        db, team.id, 10.0, CreditTransactionProvider.revolut, external_reference="revolut:o1"
+    )
+    dup = await TeamCreditService.add_credits(
+        db, team.id, 10.0, CreditTransactionProvider.revolut, external_reference="revolut:o1"
+    )
+    assert first is not None and dup is None
+    assert await TeamCreditService.get_balance(db, team.id) == 10.0
+
+
+@pytest.mark.asyncio
+async def test_use_credits_drains_oldest_first(db):
+    team = await _team(db)
+    tx1 = await TeamCreditService.add_credits(db, team.id, 30.0, CreditTransactionProvider.revolut)
+    tx2 = await TeamCreditService.add_credits(db, team.id, 30.0, CreditTransactionProvider.revolut)
+    assert await TeamCreditService.use_credits(db, team.id, 40.0) is True
+    assert tx1.amount_left == 0.0
+    assert tx2.amount_left == 20.0
+
+
+@pytest.mark.asyncio
+async def test_use_credits_insufficient_no_partial(db):
+    team = await _team(db)
+    tx = await TeamCreditService.add_credits(db, team.id, 10.0, CreditTransactionProvider.revolut)
+    assert await TeamCreditService.use_credits(db, team.id, 25.0) is False
+    assert tx.amount_left == 10.0  # untouched without allow_partial
+
+
+@pytest.mark.asyncio
+async def test_use_credits_allow_partial_drains_to_zero(db):
+    team = await _team(db)
+    await TeamCreditService.add_credits(db, team.id, 10.0, CreditTransactionProvider.revolut)
+    assert await TeamCreditService.use_credits(db, team.id, 25.0, allow_partial=True) is False
+    assert await TeamCreditService.get_balance(db, team.id) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_ledger_entry_written(db):
+    from sqlalchemy import select
+
+    from src.models.team_ledger_entry import TeamLedgerEntry
+
+    team = await _team(db)
+    await TeamCreditService.log(db, team.id, "monthly_renewal", 36.0, {"seats": 2})
+    entry = (await db.execute(select(TeamLedgerEntry).where(TeamLedgerEntry.team_id == team.id))).scalar_one()
+    assert entry.entry_type == "monthly_renewal" and entry.amount == 36.0

--- a/tests/test_team_extra_credits.py
+++ b/tests/test_team_extra_credits.py
@@ -1,0 +1,300 @@
+"""Team extra-credits gating: entitlement context, chokepoint drain, personal blocks.
+
+The pure/entitlement tests use the rolled-back ``db`` fixture. The chokepoint and
+route tests exercise the real services (which open their own ``AsyncSessionLocal``),
+so they seed via committed sessions and clean up their own rows — mirroring
+``tests/test_inference_call_billing.py`` and ``tests/test_payment_routes.py``.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import delete, select
+
+from src.interfaces.api_keys import ApiKeyType
+from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.models.api_key import ApiKey as ApiKeyDB
+from src.models.base import AsyncSessionLocal
+from src.models.credit_transaction import CreditTransaction
+from src.models.inference_call import InferenceCall
+from src.models.plan_subscription import PlanSubscription
+from src.models.team import Team
+from src.models.team_credit_transaction import TeamCreditTransaction
+from src.models.team_ledger_entry import TeamLedgerEntry
+from src.models.team_membership import ROLE_MEMBER, TeamMembership
+from src.models.user import User
+from src.services.api_key import ApiKeyService
+from src.services.auth_tokens import create_access_token
+from src.services.entitlement import compute_source, get_team_extra_context
+from src.services.payments.registry import payment_registry
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+from src.services.team_credit import TeamCreditService
+from src.services.teams import TeamService
+from src.subscription_tiers import get_tier
+
+
+async def _member_with_seat(db, member_cap=None, team_cap=None, balance=100.0):
+    team = await TeamService.create_team(
+        db, "Acme", seat_prices={"plus": 16.0},
+        extra_credits_monthly_cap=team_cap, extra_credits_member_default_cap=member_cap,
+    )
+    user = User(email=f"{uuid.uuid4()}@test.dev")
+    db.add(user)
+    await db.flush()
+    db.add(TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_MEMBER))
+    seat = PlanSubscription(
+        user_id=user.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+        team_id=team.id, seat_price_snapshot=16.0,
+        current_period_start=datetime.now(), current_period_end=datetime.now() + timedelta(days=20),
+    )
+    db.add(seat)
+    await db.flush()
+    if balance:
+        await TeamCreditService.add_credits(db, team.id, balance, CreditTransactionProvider.revolut)
+    return team, user
+
+
+def test_compute_source_team_path():
+    tier = get_tier("free")  # tiny windows: 0.5 / 2.0
+    # Windows exhausted, no prepaid, team available -> "team"
+    assert compute_source(tier, 0.5, 2.0, 0.0, team_extra_available=5.0) == "team"
+    # Windows exhausted, nothing anywhere -> blocked
+    assert compute_source(tier, 0.5, 2.0, 0.0, team_extra_available=0.0) == "blocked"
+    # Windows open -> tier, regardless of team
+    assert compute_source(tier, 0.0, 0.0, 0.0, team_extra_available=5.0) == "tier"
+
+
+@pytest.mark.asyncio
+async def test_context_caps_default_to_zero(db):
+    _, user = await _member_with_seat(db, member_cap=None, team_cap=None)
+    ctx = await get_team_extra_context(db, user.id, datetime.now())
+    assert ctx is not None and ctx.available == 0.0  # caps unset -> blocked
+
+
+@pytest.mark.asyncio
+async def test_context_min_of_caps_and_balance(db):
+    team, user = await _member_with_seat(db, member_cap=10.0, team_cap=50.0, balance=7.0)
+    ctx = await get_team_extra_context(db, user.id, datetime.now())
+    assert ctx.available == 7.0  # balance is the binding constraint
+
+    await TeamCreditService.add_credits(db, team.id, 100.0, CreditTransactionProvider.revolut)
+    ctx = await get_team_extra_context(db, user.id, datetime.now())
+    assert ctx.available == 10.0  # member cap binds now
+
+
+@pytest.mark.asyncio
+async def test_context_subtracts_month_to_date_team_spend(db):
+    team, user = await _member_with_seat(db, member_cap=50.0, team_cap=20.0, balance=100.0)
+    key = ApiKeyDB(key=f"k-{uuid.uuid4()}", user_id=user.id, name="k", type=ApiKeyType.api)
+    db.add(key)
+    await db.flush()
+    # 12 total, 4 window-covered -> 8 team-funded this month.
+    call = InferenceCall(api_key_id=key.id, credits_used=12.0, model_name="m",
+                         tier_credits_used=4.0, team_id=team.id)
+    call.used_at = datetime.now()
+    db.add(call)
+    await db.flush()
+    ctx = await get_team_extra_context(db, user.id, datetime.now())
+    assert ctx.available == 12.0  # team cap 20 - 8 spent
+
+
+@pytest.mark.asyncio
+async def test_context_none_for_non_member_and_zero_for_suspended(db):
+    outsider = User(email=f"{uuid.uuid4()}@test.dev")
+    db.add(outsider)
+    await db.flush()
+    assert await get_team_extra_context(db, outsider.id, datetime.now()) is None
+
+    team, user = await _member_with_seat(db, member_cap=10.0, team_cap=50.0)
+    team.status = "suspended"
+    ctx = await get_team_extra_context(db, user.id, datetime.now())
+    assert ctx.available == 0.0
+
+
+@pytest.mark.asyncio
+async def test_member_override_beats_team_default(db):
+    team, user = await _member_with_seat(db, member_cap=10.0, team_cap=50.0)
+    membership = await TeamService.get_membership(db, user.id)
+    membership.extra_credits_cap_override = 3.0
+    await db.flush()
+    ctx = await get_team_extra_context(db, user.id, datetime.now())
+    assert ctx.available == 3.0
+
+
+# --- chokepoint (committed sessions; register_inference_call opens its own) ---
+
+
+async def _committed_member(*, member_cap, team_cap, balance, personal_prepaid=0.0):
+    """Seed a committed team + member + api key. Returns (team_id, user_id, key_str)."""
+    async with AsyncSessionLocal() as db:
+        team = await TeamService.create_team(
+            db, "Acme", seat_prices={"plus": 16.0},
+            extra_credits_monthly_cap=team_cap, extra_credits_member_default_cap=member_cap,
+        )
+        user = User(email=f"{uuid.uuid4()}@test.dev", email_verified=True)
+        db.add(user)
+        await db.flush()
+        db.add(TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_MEMBER))
+        key = ApiKeyDB(key=f"k-{uuid.uuid4()}", user_id=user.id, name="k", type=ApiKeyType.api)
+        db.add(key)
+        if personal_prepaid:
+            db.add(CreditTransaction(
+                user_id=user.id, amount=personal_prepaid, amount_left=personal_prepaid,
+                provider=CreditTransactionProvider.revolut, status=CreditTransactionStatus.completed,
+            ))
+        await db.flush()
+        if balance:
+            await TeamCreditService.add_credits(db, team.id, balance, CreditTransactionProvider.revolut)
+        await db.commit()
+        return team.id, user.id, key.key
+
+
+async def _cleanup_member(team_id, user_id):
+    async with AsyncSessionLocal() as db:
+        from src.models.entitlement_window import EntitlementWindow
+
+        await db.execute(delete(TeamLedgerEntry).where(TeamLedgerEntry.team_id == team_id))
+        await db.execute(delete(TeamCreditTransaction).where(TeamCreditTransaction.team_id == team_id))
+        await db.execute(delete(CreditTransaction).where(CreditTransaction.user_id == user_id))
+        await db.execute(delete(EntitlementWindow).where(EntitlementWindow.user_id == user_id))
+        await db.execute(delete(PlanSubscription).where(PlanSubscription.user_id == user_id))
+        await db.execute(delete(TeamMembership).where(TeamMembership.user_id == user_id))
+        # inference_calls cascade via api_keys FK; delete keys then user, then team.
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.user_id == user_id))
+        await db.execute(delete(User).where(User.id == user_id))
+        await db.execute(delete(Team).where(Team.id == team_id))
+        await db.commit()
+
+
+async def test_register_inference_call_drains_team_and_stamps():
+    # Free-tier windows (5h=0.5, weekly=2.0); a 3.0 call is 0.5 tier-covered, 2.5 overflow.
+    team_id, user_id, key = await _committed_member(
+        member_cap=100.0, team_cap=100.0, balance=100.0, personal_prepaid=5.0
+    )
+    try:
+        ok = await ApiKeyService.register_inference_call(key, credits_used=3.0, model_name="m")
+        assert ok is True
+        async with AsyncSessionLocal() as s:
+            call = (
+                await s.execute(
+                    select(InferenceCall)
+                    .join(ApiKeyDB, InferenceCall.api_key_id == ApiKeyDB.id)
+                    .where(ApiKeyDB.user_id == user_id)
+                )
+            ).scalar_one()
+            # (1) the row is stamped with the funding team.
+            assert call.team_id == team_id
+            assert call.tier_credits_used == pytest.approx(0.5)
+            # (2) team balance dropped by (credits_used - tier_credits_used) = 2.5.
+            assert await TeamCreditService.get_balance(s, team_id) == pytest.approx(97.5)
+            # (3) an extra_credits_usage ledger entry for that amount exists.
+            entry = (
+                await s.execute(
+                    select(TeamLedgerEntry).where(
+                        TeamLedgerEntry.team_id == team_id,
+                        TeamLedgerEntry.entry_type == "extra_credits_usage",
+                    )
+                )
+            ).scalar_one()
+            assert entry.amount == pytest.approx(2.5)
+            # (4) the member's PERSONAL prepaid is untouched.
+            personal = (
+                await s.execute(select(CreditTransaction).where(CreditTransaction.user_id == user_id))
+            ).scalar_one()
+            assert personal.amount_left == pytest.approx(5.0)
+    finally:
+        await _cleanup_member(team_id, user_id)
+
+
+async def test_register_inference_call_blocked_caps_leaves_team_balance():
+    # Caps unset (None -> 0): the member has a team but zero headroom, so the overflow
+    # is NOT drained, team_id stays NULL, and the balance is left intact.
+    team_id, user_id, key = await _committed_member(
+        member_cap=None, team_cap=None, balance=100.0, personal_prepaid=5.0
+    )
+    try:
+        ok = await ApiKeyService.register_inference_call(key, credits_used=3.0, model_name="m")
+        assert ok is True
+        async with AsyncSessionLocal() as s:
+            call = (
+                await s.execute(
+                    select(InferenceCall)
+                    .join(ApiKeyDB, InferenceCall.api_key_id == ApiKeyDB.id)
+                    .where(ApiKeyDB.user_id == user_id)
+                )
+            ).scalar_one()
+            assert call.team_id is None  # not funded by the team
+            # Team balance untouched (nothing drained).
+            assert await TeamCreditService.get_balance(s, team_id) == pytest.approx(100.0)
+            # No extra_credits_usage ledger entry written.
+            entries = (
+                await s.execute(
+                    select(TeamLedgerEntry).where(
+                        TeamLedgerEntry.team_id == team_id,
+                        TeamLedgerEntry.entry_type == "extra_credits_usage",
+                    )
+                )
+            ).scalars().all()
+            assert entries == []
+            # Personal prepaid untouched (members never spend it).
+            personal = (
+                await s.execute(select(CreditTransaction).where(CreditTransaction.user_id == user_id))
+            ).scalar_one()
+            assert personal.amount_left == pytest.approx(5.0)
+    finally:
+        await _cleanup_member(team_id, user_id)
+
+
+# --- route guards: members can't hold personal credits ---
+
+
+async def _committed_member_only():
+    """A committed email member with no seat. Returns (team_id, user_id, email)."""
+    async with AsyncSessionLocal() as db:
+        team = await TeamService.create_team(db, "Acme", seat_prices={"plus": 16.0})
+        email = f"{uuid.uuid4()}@test.dev"
+        user = User(email=email, email_verified=True)
+        db.add(user)
+        await db.flush()
+        db.add(TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_MEMBER))
+        await db.commit()
+        return team.id, user.id, email
+
+
+async def _cleanup_member_only(team_id, user_id):
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(CreditTransaction).where(CreditTransaction.user_id == user_id))
+        await db.execute(delete(TeamMembership).where(TeamMembership.user_id == user_id))
+        await db.execute(delete(User).where(User.id == user_id))
+        await db.execute(delete(Team).where(Team.id == team_id))
+        await db.commit()
+
+
+async def test_personal_topup_and_voucher_blocked_for_members(async_client, monkeypatch):
+    from src.config import config
+
+    monkeypatch.setattr("src.routes.payments.payments.resolve_currency", lambda request: "USD")
+    monkeypatch.setattr(config, "VOUCHERS_PASSWORDS", ["vpw"])
+    revolut = payment_registry.get("revolut")
+    monkeypatch.setattr(revolut, "secret_key", "sk_test")
+    monkeypatch.setattr(revolut, "webhook_secret", "wsk_test")
+
+    team_id, user_id, email = await _committed_member_only()
+    headers = {"Authorization": f"Bearer {create_access_token(user_id)}"}
+    try:
+        # Personal top-up: blocked because the caller is a team member.
+        resp = await async_client.post(
+            "/payments/topup", json={"provider": "revolut", "amount": 10}, headers=headers
+        )
+        assert resp.status_code == 400, resp.text
+        assert "team" in resp.json()["detail"].lower()
+
+        # Voucher to a member's email: blocked for the same reason.
+        resp = await async_client.post(
+            "/credits/vouchers", json={"email": email, "amount": 5, "password": "vpw"}
+        )
+        assert resp.status_code == 400, resp.text
+        assert "team" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup_member_only(team_id, user_id)

--- a/tests/test_team_extra_credits.py
+++ b/tests/test_team_extra_credits.py
@@ -17,6 +17,7 @@ from src.interfaces.credits import CreditTransactionProvider, CreditTransactionS
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.credit_transaction import CreditTransaction
+from src.models.entitlement_window import EntitlementWindow
 from src.models.inference_call import InferenceCall
 from src.models.plan_subscription import PlanSubscription
 from src.models.team import Team
@@ -26,7 +27,7 @@ from src.models.team_membership import ROLE_MEMBER, TeamMembership
 from src.models.user import User
 from src.services.api_key import ApiKeyService
 from src.services.auth_tokens import create_access_token
-from src.services.entitlement import compute_source, get_team_extra_context
+from src.services.entitlement import WINDOW_5H, WINDOW_WEEKLY, compute_source, get_team_extra_context
 from src.services.payments.registry import payment_registry
 from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
 from src.services.team_credit import TeamCreditService
@@ -242,6 +243,92 @@ async def test_register_inference_call_blocked_caps_leaves_team_balance():
                 await s.execute(select(CreditTransaction).where(CreditTransaction.user_id == user_id))
             ).scalar_one()
             assert personal.amount_left == pytest.approx(5.0)
+    finally:
+        await _cleanup_member(team_id, user_id)
+
+
+async def test_register_inference_call_partial_headroom_ledger_matches_drain():
+    # Balance 1.0 binds below the caps (5.0). A 3.5 call is 0.5 tier-covered, 3.0 overflow,
+    # but only 1.0 can be drained -> the ledger records the 1.0 actually deducted, not 3.0.
+    team_id, user_id, key = await _committed_member(member_cap=5.0, team_cap=5.0, balance=1.0)
+    try:
+        ok = await ApiKeyService.register_inference_call(key, credits_used=3.5, model_name="m")
+        assert ok is True
+        async with AsyncSessionLocal() as s:
+            assert await TeamCreditService.get_balance(s, team_id) == pytest.approx(0.0)
+            entry = (
+                await s.execute(
+                    select(TeamLedgerEntry).where(
+                        TeamLedgerEntry.team_id == team_id,
+                        TeamLedgerEntry.entry_type == "extra_credits_usage",
+                    )
+                )
+            ).scalar_one()
+            assert entry.amount == pytest.approx(1.0)
+    finally:
+        await _cleanup_member(team_id, user_id)
+
+
+# --- batched gateway path: seat member with exhausted windows (spec-mandated) ---
+
+
+async def _committed_member_exhausted(*, member_cap, team_cap, balance):
+    """Committed member with an active PLUS seat, both entitlement windows exhausted,
+    and zero personal balance. Returns (team_id, user_id, key_str)."""
+    now = datetime.now()
+    async with AsyncSessionLocal() as db:
+        team = await TeamService.create_team(
+            db, "Acme", seat_prices={"plus": 16.0},
+            extra_credits_monthly_cap=team_cap, extra_credits_member_default_cap=member_cap,
+        )
+        user = User(email=f"{uuid.uuid4()}@test.dev", email_verified=True)
+        db.add(user)
+        await db.flush()
+        db.add(TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_MEMBER))
+        db.add(
+            PlanSubscription(
+                user_id=user.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+                team_id=team.id, seat_price_snapshot=16.0,
+                current_period_start=now, current_period_end=now + timedelta(days=20),
+            )
+        )
+        key = ApiKeyDB(key=f"k-{uuid.uuid4()}", user_id=user.id, name="k", type=ApiKeyType.api)
+        db.add(key)
+        await db.flush()
+        # Open both windows now and fill them past the plus limits (7 / 30) with one
+        # tier-covered call so the gateway must fall through to the team path.
+        for kind, dur in ((WINDOW_5H, timedelta(hours=5)), (WINDOW_WEEKLY, timedelta(days=7))):
+            db.add(
+                EntitlementWindow(
+                    user_id=user.id, kind=kind,
+                    started_at=now - timedelta(minutes=1), expires_at=now + dur,
+                )
+            )
+        call = InferenceCall(api_key_id=key.id, credits_used=30.0, model_name="m", tier_credits_used=30.0)
+        call.used_at = now
+        db.add(call)
+        if balance:
+            await TeamCreditService.add_credits(db, team.id, balance, CreditTransactionProvider.revolut)
+        await db.commit()
+        return team.id, user.id, key.key
+
+
+async def test_gateway_includes_seat_member_with_team_headroom():
+    team_id, user_id, key = await _committed_member_exhausted(
+        member_cap=100.0, team_cap=100.0, balance=100.0
+    )
+    try:
+        assert key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup_member(team_id, user_id)
+
+
+async def test_gateway_excludes_seat_member_with_zero_caps():
+    team_id, user_id, key = await _committed_member_exhausted(
+        member_cap=None, team_cap=None, balance=100.0
+    )
+    try:
+        assert key not in await ApiKeyService.get_admin_all_api_keys()
     finally:
         await _cleanup_member(team_id, user_id)
 

--- a/tests/test_team_invites.py
+++ b/tests/test_team_invites.py
@@ -1,0 +1,97 @@
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from src.interfaces.credits import CreditTransactionProvider
+from src.models.credit_transaction import CreditTransaction
+from src.models.plan_subscription import PlanSubscription
+from src.models.team_invite import TeamInvite
+from src.models.team_membership import ROLE_ADMIN, ROLE_MEMBER
+from src.models.user import User
+from src.services.teams import TeamService
+
+
+async def _team_and_user(db, email=None):
+    team = await TeamService.create_team(db, "Acme", seat_prices={"plus": 16.0})
+    user = User(email=email or f"{uuid.uuid4()}@test.dev", email_verified=True)
+    db.add(user)
+    await db.flush()
+    return team, user
+
+
+@pytest.mark.asyncio
+async def test_invite_token_hashed_and_accept(db):
+    team, user = await _team_and_user(db)
+    invite, token = await TeamService.create_invite(db, team.id, user.email.upper(), ROLE_MEMBER, "staff")
+    assert invite.token_hash != token  # never stored in plaintext
+    assert invite.email == user.email.lower()
+
+    membership = await TeamService.accept_invite(db, token, user)
+    assert membership.team_id == team.id and membership.role == ROLE_MEMBER
+    assert invite.status == "accepted"
+    # Single-use: second acceptance fails.
+    other = User(email=f"{uuid.uuid4()}@test.dev")
+    db.add(other)
+    await db.flush()
+    with pytest.raises(ValueError, match="Invalid or expired"):
+        await TeamService.accept_invite(db, token, other)
+
+
+@pytest.mark.asyncio
+async def test_accept_requires_email_match(db):
+    team, user = await _team_and_user(db)
+    _, token = await TeamService.create_invite(db, team.id, "someone.else@corp.dev", ROLE_MEMBER, "staff")
+    with pytest.raises(ValueError, match="different email"):
+        await TeamService.accept_invite(db, token, user)
+
+
+@pytest.mark.asyncio
+async def test_accept_blocked_by_active_sub_and_balance(db):
+    team, user = await _team_and_user(db)
+    _, token = await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")
+
+    sub = PlanSubscription(user_id=user.id, tier="plus", provider="revolut", status="active")
+    db.add(sub)
+    await db.flush()
+    with pytest.raises(ValueError, match="subscription"):
+        await TeamService.accept_invite(db, token, user)
+
+    sub.status = "expired"
+    db.add(CreditTransaction(user_id=user.id, amount=5.0, amount_left=5.0,
+                             provider=CreditTransactionProvider.voucher))
+    await db.flush()
+    with pytest.raises(ValueError, match="balance"):
+        await TeamService.accept_invite(db, token, user)
+
+
+@pytest.mark.asyncio
+async def test_accept_blocked_if_already_in_a_team(db):
+    team, user = await _team_and_user(db)
+    _, token = await TeamService.create_invite(db, team.id, user.email, ROLE_ADMIN, "staff")
+    await TeamService.accept_invite(db, token, user)
+
+    team2 = await TeamService.create_team(db, "Other")
+    _, token2 = await TeamService.create_invite(db, team2.id, user.email, ROLE_MEMBER, "staff")
+    with pytest.raises(ValueError, match="already"):
+        await TeamService.accept_invite(db, token2, user)
+
+
+@pytest.mark.asyncio
+async def test_expired_invite_rejected(db):
+    team, user = await _team_and_user(db)
+    invite, token = await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")
+    invite.expires_at = datetime.now() - timedelta(days=1)
+    await db.flush()
+    with pytest.raises(ValueError, match="Invalid or expired"):
+        await TeamService.accept_invite(db, token, user)
+
+
+@pytest.mark.asyncio
+async def test_new_invite_revokes_older_pending_for_same_email(db):
+    team, user = await _team_and_user(db)
+    old, _ = await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")
+    await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")
+    refreshed = (await db.execute(select(TeamInvite).where(TeamInvite.id == old.id))).scalar_one()
+    assert refreshed.status == "revoked"

--- a/tests/test_team_invites.py
+++ b/tests/test_team_invites.py
@@ -79,6 +79,27 @@ async def test_accept_blocked_if_already_in_a_team(db):
 
 
 @pytest.mark.asyncio
+async def test_accept_duplicate_membership_race_raises_value_error(db, monkeypatch):
+    """If the get_membership check is raced past, the unique constraint surfaces as
+    ValueError (not a raw IntegrityError 500)."""
+    from src.models.team_membership import TeamMembership
+
+    team, user = await _team_and_user(db)
+    _, token = await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")
+    # Pre-existing membership simulates a concurrent accept that already committed.
+    db.add(TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_MEMBER))
+    await db.flush()
+    # Make the pre-insert guard miss it, forcing the flush to trip the unique constraint.
+    monkeypatch.setattr(TeamService, "get_membership", staticmethod(lambda db, user_id: _none()))
+    with pytest.raises(ValueError, match="already in a team"):
+        await TeamService.accept_invite(db, token, user)
+
+
+async def _none():
+    return None
+
+
+@pytest.mark.asyncio
 async def test_expired_invite_rejected(db):
     team, user = await _team_and_user(db)
     invite, token = await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")

--- a/tests/test_team_invites.py
+++ b/tests/test_team_invites.py
@@ -95,3 +95,15 @@ async def test_new_invite_revokes_older_pending_for_same_email(db):
     await TeamService.create_invite(db, team.id, user.email, ROLE_MEMBER, "staff")
     refreshed = (await db.execute(select(TeamInvite).where(TeamInvite.id == old.id))).scalar_one()
     assert refreshed.status == "revoked"
+
+
+@pytest.mark.asyncio
+async def test_accept_requires_verified_email(db):
+    team = await TeamService.create_team(db, "Acme", seat_prices={"plus": 16.0})
+    email = f"{uuid.uuid4()}@test.dev"
+    user = User(email=email, email_verified=False)
+    db.add(user)
+    await db.flush()
+    _, token = await TeamService.create_invite(db, team.id, email, ROLE_MEMBER, "staff")
+    with pytest.raises(ValueError, match="Verify your email"):
+        await TeamService.accept_invite(db, token, user)

--- a/tests/test_team_models.py
+++ b/tests/test_team_models.py
@@ -1,0 +1,64 @@
+"""Schema smoke tests for the Teams tables (created by conftest from metadata)."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from src.models.inference_call import InferenceCall
+from src.models.plan_subscription import PlanSubscription
+from src.models.team import Team
+from src.models.team_membership import ROLE_ADMIN, TeamMembership
+from src.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_team_membership_roundtrip(db):
+    user = User(email=f"{uuid.uuid4()}@test.dev")
+    team = Team(name="Acme")
+    db.add_all([user, team])
+    await db.flush()
+
+    db.add(TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_ADMIN))
+    await db.flush()
+
+    loaded = (await db.execute(select(TeamMembership).where(TeamMembership.user_id == user.id))).scalar_one()
+    assert loaded.team_id == team.id
+    assert loaded.role == ROLE_ADMIN
+    assert team.status == "active"
+    assert team.seat_prices == {}
+
+
+@pytest.mark.asyncio
+async def test_one_team_per_user_unique(db):
+    user = User(email=f"{uuid.uuid4()}@test.dev")
+    t1, t2 = Team(name="A"), Team(name="B")
+    db.add_all([user, t1, t2])
+    await db.flush()
+    db.add(TeamMembership(team_id=t1.id, user_id=user.id))
+    await db.flush()
+    db.add(TeamMembership(team_id=t2.id, user_id=user.id))
+    with pytest.raises(Exception):  # IntegrityError, wrapped by driver
+        await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_seat_columns_on_plan_subscription(db):
+    user = User(email=f"{uuid.uuid4()}@test.dev")
+    team = Team(name="Acme")
+    db.add_all([user, team])
+    await db.flush()
+    sub = PlanSubscription(
+        user_id=user.id, tier="plus", provider="team_credits",
+        status="active", team_id=team.id, seat_price_snapshot=16.0,
+    )
+    db.add(sub)
+    await db.flush()
+    assert sub.team_id == team.id and sub.seat_price_snapshot == 16.0
+
+
+@pytest.mark.asyncio
+async def test_inference_call_team_id(db):
+    # team_id is nullable and defaults to None; settable via kwarg.
+    call = InferenceCall(api_key_id=uuid.uuid4(), credits_used=1.0, model_name="m", team_id=None)
+    assert call.team_id is None

--- a/tests/test_team_routes.py
+++ b/tests/test_team_routes.py
@@ -393,6 +393,20 @@ async def test_admin_topup_returns_checkout_url(async_client, monkeypatch):
         await _cleanup(team.id, admin.id, member.id)
 
 
+async def test_remove_nonmember_target_returns_400(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    nonmember = await _make_user()
+    try:
+        # Team admin tries to remove a user who is NOT a member of the team.
+        resp = await async_client.delete(
+            f"/teams/{team.id}/members/{nonmember.id}", headers=_auth(admin.id)
+        )
+        assert resp.status_code == 400, resp.text
+        assert "member" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup(team.id, admin.id, nonmember.id)
+
+
 # ---------------------------------------------------------------- Member endpoints
 
 

--- a/tests/test_team_routes.py
+++ b/tests/test_team_routes.py
@@ -187,6 +187,34 @@ async def test_staff_update_prices_and_suspend(async_client, monkeypatch):
         await _cleanup(team.id, admin.id, member.id)
 
 
+async def test_staff_update_prices_rejects_orphaning_active_seat(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    team, admin = await _seed_team(seat_prices={"plus": 16.0, "max": 80.0})
+    member = await _add_member(team.id)
+    async with AsyncSessionLocal() as db:
+        db.add(
+            PlanSubscription(
+                user_id=member.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+                team_id=team.id, seat_price_snapshot=16.0,
+                current_period_start=datetime.now(), current_period_end=datetime.now() + timedelta(days=15),
+            )
+        )
+        await db.commit()
+    try:
+        # New map drops "plus", still used by an active seat -> 400 naming the tier.
+        resp = await async_client.patch(
+            f"/teams/admin/{team.id}", json={"seat_prices": {"max": 90.0}}, headers=headers
+        )
+        assert resp.status_code == 400, resp.text
+        assert "plus" in resp.json()["detail"]
+        # Prices untouched after the rejection.
+        async with AsyncSessionLocal() as db:
+            t = (await db.execute(select(Team).where(Team.id == team.id))).scalar_one()
+            assert t.seat_prices == {"plus": 16.0, "max": 80.0}
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
 async def test_staff_update_missing_team_404(async_client, monkeypatch):
     headers = _staff_headers(monkeypatch)
     resp = await async_client.patch(f"/teams/admin/{uuid.uuid4()}", json={"name": "X"}, headers=headers)
@@ -344,6 +372,77 @@ async def test_admin_caps_endpoints(async_client, monkeypatch):
                 await db.execute(select(TeamMembership).where(TeamMembership.user_id == member.id))
             ).scalar_one()
             assert m.extra_credits_cap_override == 5.0
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_caps_patch_leaves_omitted_field_unchanged(async_client, monkeypatch):
+    team, admin = await _seed_team(extra_credits_monthly_cap=200.0, extra_credits_member_default_cap=20.0)
+    try:
+        # PATCH only the monthly cap; the omitted member default must stay at 20.0.
+        resp = await async_client.patch(
+            f"/teams/{team.id}/caps", json={"extra_credits_monthly_cap": 300.0}, headers=_auth(admin.id)
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["extra_credits_monthly_cap"] == 300.0
+        assert resp.json()["extra_credits_member_default_cap"] == 20.0
+        async with AsyncSessionLocal() as db:
+            t = (await db.execute(select(Team).where(Team.id == team.id))).scalar_one()
+            assert t.extra_credits_member_default_cap == 20.0
+    finally:
+        await _cleanup(team.id, admin.id)
+
+
+async def test_seat_holder_blocked_from_subscribe_and_upgrade(async_client, monkeypatch):
+    monkeypatch.setattr("src.routes.payments.payments.resolve_currency", lambda request: "USD")
+    revolut = payment_registry.get("revolut")
+    monkeypatch.setattr(revolut, "secret_key", "sk_test")
+    monkeypatch.setattr(revolut, "webhook_secret", "wsk_test")
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    async with AsyncSessionLocal() as db:
+        db.add(
+            PlanSubscription(
+                user_id=member.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+                team_id=team.id, seat_price_snapshot=16.0,
+                current_period_start=datetime.now(), current_period_end=datetime.now() + timedelta(days=15),
+            )
+        )
+        await db.commit()
+    h = _auth(member.id)
+    try:
+        resp = await async_client.post(
+            "/payments/subscribe", json={"provider": "revolut", "tier": "max"}, headers=h
+        )
+        assert resp.status_code == 400, resp.text
+        assert "team" in resp.json()["detail"].lower()
+        resp = await async_client.post(
+            "/payments/upgrade", json={"provider": "revolut", "tier": "max"}, headers=h
+        )
+        assert resp.status_code == 400, resp.text
+        assert "team" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_seat_holder_subscription_shows_team_name(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    async with AsyncSessionLocal() as db:
+        db.add(
+            PlanSubscription(
+                user_id=member.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+                team_id=team.id, seat_price_snapshot=16.0,
+                current_period_start=datetime.now(), current_period_end=datetime.now() + timedelta(days=15),
+            )
+        )
+        await db.commit()
+    try:
+        resp = await async_client.get("/payments/subscription", headers=_auth(member.id))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_team_seat"] is True
+        assert body["team_name"] == team.name
     finally:
         await _cleanup(team.id, admin.id, member.id)
 

--- a/tests/test_team_routes.py
+++ b/tests/test_team_routes.py
@@ -1,0 +1,540 @@
+"""Team HTTP surface: staff, team-admin and member endpoints + IDOR guards.
+
+Follows ``tests/test_payment_routes.py``: real JWTs via ``create_access_token``,
+committed seed sessions (routes open their own ``AsyncSessionLocal``), and per-test
+cleanup (the ``async_client`` fixture does no rollback).
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import delete, select
+
+from src.config import config
+from src.interfaces.credits import CreditTransactionProvider
+from src.models.base import AsyncSessionLocal
+from src.models.credit_transaction import CreditTransaction
+from src.models.plan_subscription import PlanSubscription
+from src.models.team import Team
+from src.models.team_credit_transaction import TeamCreditTransaction
+from src.models.team_invite import TeamInvite
+from src.models.team_ledger_entry import TeamLedgerEntry
+from src.models.team_membership import ROLE_ADMIN, ROLE_MEMBER, TeamMembership
+from src.models.user import User
+from src.services.auth_tokens import create_access_token
+from src.services.payments.base import CheckoutResult
+from src.services.payments.registry import payment_registry
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+from src.services.team_credit import TeamCreditService
+from src.services.teams import TeamService
+
+ADMIN_TOKEN = "test-admin-token"
+
+
+def _staff_headers(monkeypatch) -> dict:
+    monkeypatch.setattr(config, "ADMIN_SECRET", ADMIN_TOKEN)
+    return {"x-admin-token": ADMIN_TOKEN}
+
+
+def _auth(user_id: uuid.UUID) -> dict:
+    return {"Authorization": f"Bearer {create_access_token(user_id)}"}
+
+
+async def _make_user(email: str | None = None, verified: bool = True) -> User:
+    async with AsyncSessionLocal() as db:
+        user = User(email=email or f"team-{uuid.uuid4().hex}@example.com", email_verified=verified)
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+    return user
+
+
+async def _seed_team(seat_prices=None, **caps) -> tuple[Team, User]:
+    """Committed team with one admin. Returns (team, admin_user)."""
+    async with AsyncSessionLocal() as db:
+        team = await TeamService.create_team(db, "Acme", seat_prices=seat_prices or {"plus": 16.0}, **caps)
+        admin = User(email=f"admin-{uuid.uuid4().hex}@example.com", email_verified=True)
+        db.add(admin)
+        await db.flush()
+        db.add(TeamMembership(team_id=team.id, user_id=admin.id, role=ROLE_ADMIN))
+        await db.commit()
+        await db.refresh(team)
+        await db.refresh(admin)
+    return team, admin
+
+
+async def _add_member(team_id: uuid.UUID, role: str = ROLE_MEMBER) -> User:
+    async with AsyncSessionLocal() as db:
+        user = User(email=f"member-{uuid.uuid4().hex}@example.com", email_verified=True)
+        db.add(user)
+        await db.flush()
+        db.add(TeamMembership(team_id=team_id, user_id=user.id, role=role))
+        await db.commit()
+        await db.refresh(user)
+    return user
+
+
+async def _topup_team(team_id: uuid.UUID, amount: float) -> None:
+    async with AsyncSessionLocal() as db:
+        await TeamCreditService.add_credits(db, team_id, amount, CreditTransactionProvider.revolut)
+        await db.commit()
+
+
+async def _cleanup(team_id: uuid.UUID, *user_ids: uuid.UUID) -> None:
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(TeamLedgerEntry).where(TeamLedgerEntry.team_id == team_id))
+        await db.execute(delete(TeamCreditTransaction).where(TeamCreditTransaction.team_id == team_id))
+        await db.execute(delete(TeamInvite).where(TeamInvite.team_id == team_id))
+        await db.execute(delete(PlanSubscription).where(PlanSubscription.team_id == team_id))
+        await db.execute(delete(TeamMembership).where(TeamMembership.team_id == team_id))
+        for uid in user_ids:
+            await db.execute(delete(PlanSubscription).where(PlanSubscription.user_id == uid))
+            await db.execute(delete(CreditTransaction).where(CreditTransaction.user_id == uid))
+            await db.execute(delete(TeamMembership).where(TeamMembership.user_id == uid))
+            await db.execute(delete(User).where(User.id == uid))
+        await db.execute(delete(Team).where(Team.id == team_id))
+        await db.commit()
+
+
+def _enable_revolut(monkeypatch, order_id: str):
+    revolut = payment_registry.get("revolut")
+    monkeypatch.setattr(revolut, "secret_key", "sk_test")
+    monkeypatch.setattr(revolut, "webhook_secret", "wsk_test")
+    monkeypatch.setattr(config, "FRONTEND_URL", "https://console.libertai.io")
+
+    async def fake_create_topup(
+        *, amount, currency, redirect_url, user_email=None, metadata=None, vat_rate=0.0, item_name="Credits"
+    ):
+        return CheckoutResult(checkout_url="http://pay/team-checkout", order_id=order_id)
+
+    monkeypatch.setattr(revolut, "create_topup", fake_create_topup)
+
+
+# ---------------------------------------------------------------- Staff endpoints
+
+
+async def test_staff_create_team_requires_admin_token(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    # Missing token -> rejected (FastAPI required-header validation or 401).
+    resp = await async_client.post("/teams/admin", json={"name": "Acme"})
+    assert resp.status_code in (401, 422)
+    # Wrong token -> 401.
+    resp = await async_client.post("/teams/admin", json={"name": "Acme"}, headers={"x-admin-token": "nope"})
+    assert resp.status_code == 401
+    # Valid token -> 200 + TeamResponse shape.
+    resp = await async_client.post(
+        "/teams/admin",
+        json={"name": "Acme", "seat_prices": {"plus": 16.0}, "extra_credits_monthly_cap": 100.0},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Acme"
+    assert body["status"] == "active"
+    assert body["seat_prices"] == {"plus": 16.0}
+    assert body["extra_credits_monthly_cap"] == 100.0
+    team_id = uuid.UUID(body["id"])
+    await _cleanup(team_id)
+
+
+async def test_staff_create_team_rejects_bad_seat_price(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    resp = await async_client.post(
+        "/teams/admin", json={"name": "Bad", "seat_prices": {"free": 5.0}}, headers=headers
+    )
+    assert resp.status_code == 400, resp.text
+    assert "tier" in resp.json()["detail"].lower()
+
+
+async def test_staff_update_prices_and_suspend(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    # Give the member an active seat so suspension has something to expire.
+    async with AsyncSessionLocal() as db:
+        db.add(
+            PlanSubscription(
+                user_id=member.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+                team_id=team.id, seat_price_snapshot=16.0,
+                current_period_start=datetime.now(), current_period_end=datetime.now() + timedelta(days=15),
+            )
+        )
+        await db.commit()
+    try:
+        # PATCH prices.
+        resp = await async_client.patch(
+            f"/teams/admin/{team.id}", json={"seat_prices": {"plus": 20.0, "max": 90.0}}, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["seat_prices"] == {"plus": 20.0, "max": 90.0}
+
+        # Unknown tier in prices -> 400.
+        resp = await async_client.patch(
+            f"/teams/admin/{team.id}", json={"seat_prices": {"nope": 5.0}}, headers=headers
+        )
+        assert resp.status_code == 400, resp.text
+
+        # Suspend -> team suspended AND the seat expired.
+        resp = await async_client.post(f"/teams/admin/{team.id}/suspend", headers=headers)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "suspended"
+        async with AsyncSessionLocal() as db:
+            seat = (
+                await db.execute(select(PlanSubscription).where(PlanSubscription.user_id == member.id))
+            ).scalar_one()
+            assert seat.status == "expired"
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_staff_update_missing_team_404(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    resp = await async_client.patch(f"/teams/admin/{uuid.uuid4()}", json={"name": "X"}, headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_staff_first_invite(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    team, admin = await _seed_team()
+    try:
+        resp = await async_client.post(
+            f"/teams/admin/{team.id}/invites",
+            json={"email": "First.Admin@Example.com", "role": "admin"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["email"] == "first.admin@example.com"
+        assert body["role"] == "admin"
+        assert body["status"] == "pending"
+        assert body["expires_at"] is not None
+        # An invite row was persisted.
+        async with AsyncSessionLocal() as db:
+            invite = (
+                await db.execute(select(TeamInvite).where(TeamInvite.team_id == team.id))
+            ).scalar_one()
+            assert invite.email == "first.admin@example.com"
+    finally:
+        await _cleanup(team.id, admin.id)
+
+
+async def test_staff_remove_member(async_client, monkeypatch):
+    headers = _staff_headers(monkeypatch)
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    try:
+        # Staff can remove a regular member.
+        resp = await async_client.delete(f"/teams/admin/{team.id}/members/{member.id}", headers=headers)
+        assert resp.status_code == 200, resp.text
+        async with AsyncSessionLocal() as db:
+            gone = (
+                await db.execute(select(TeamMembership).where(TeamMembership.user_id == member.id))
+            ).scalar_one_or_none()
+            assert gone is None
+        # Staff cannot remove the last admin.
+        resp = await async_client.delete(f"/teams/admin/{team.id}/members/{admin.id}", headers=headers)
+        assert resp.status_code == 400, resp.text
+        assert "admin" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+# ---------------------------------------------------------------- Team admin endpoints
+
+
+async def test_admin_invite_accept_flow(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    invitee = await _make_user()
+    try:
+        # Admin creates an invite via the route (email send is mocked/logged).
+        resp = await async_client.post(
+            f"/teams/{team.id}/invites",
+            json={"email": invitee.email, "role": "member"},
+            headers=_auth(admin.id),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["email"] == invitee.email.lower()
+        assert resp.json()["status"] == "pending"
+
+        # Mint a usable token for the same invitee (the route hides the plaintext token).
+        async with AsyncSessionLocal() as db:
+            _, token = await TeamService.create_invite(db, team.id, invitee.email, "member", "staff")
+            await db.commit()
+
+        # Invitee accepts.
+        resp = await async_client.post(
+            "/teams/invites/accept", json={"token": token}, headers=_auth(invitee.id)
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Admin's /me now lists the invitee among members.
+        resp = await async_client.get("/teams/me", headers=_auth(admin.id))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert str(invitee.id) in {m["user_id"] for m in body["members"]}
+    finally:
+        await _cleanup(team.id, admin.id, invitee.id)
+
+
+async def test_admin_accept_invite_wrong_email_rejected(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    other = await _make_user()
+    try:
+        async with AsyncSessionLocal() as db:
+            _, token = await TeamService.create_invite(db, team.id, "someone-else@example.com", "member", "staff")
+            await db.commit()
+        resp = await async_client.post(
+            "/teams/invites/accept", json={"token": token}, headers=_auth(other.id)
+        )
+        assert resp.status_code == 400, resp.text
+        assert "email" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup(team.id, admin.id, other.id)
+
+
+async def test_admin_assign_seat_and_ledger(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    await _topup_team(team.id, 100.0)
+    try:
+        # Assign a seat -> prorated charge against the balance.
+        resp = await async_client.post(
+            f"/teams/{team.id}/seats",
+            json={"user_id": str(member.id), "tier": "plus"},
+            headers=_auth(admin.id),
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Ledger shows the seat charge + a topup + reduced balance.
+        resp = await async_client.get(f"/teams/{team.id}/ledger", headers=_auth(admin.id))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["balance"] < 100.0
+        assert any(c["entry_type"] == "seat_charge_prorated" for c in body["charges"])
+        assert len(body["topups"]) >= 1
+        assert body["topups"][0]["amount"] == 100.0
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_admin_caps_endpoints(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    try:
+        # Team caps.
+        resp = await async_client.patch(
+            f"/teams/{team.id}/caps",
+            json={"extra_credits_monthly_cap": 200.0, "extra_credits_member_default_cap": 20.0},
+            headers=_auth(admin.id),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["extra_credits_monthly_cap"] == 200.0
+        assert resp.json()["extra_credits_member_default_cap"] == 20.0
+
+        # Per-member override.
+        resp = await async_client.patch(
+            f"/teams/{team.id}/members/{member.id}/cap",
+            json={"extra_credits_cap_override": 5.0},
+            headers=_auth(admin.id),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["extra_credits_cap_override"] == 5.0
+        async with AsyncSessionLocal() as db:
+            m = (
+                await db.execute(select(TeamMembership).where(TeamMembership.user_id == member.id))
+            ).scalar_one()
+            assert m.extra_credits_cap_override == 5.0
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_admin_usage_view(async_client, monkeypatch):
+    team, admin = await _seed_team(extra_credits_monthly_cap=100.0, extra_credits_member_default_cap=50.0)
+    member = await _add_member(team.id)
+    try:
+        resp = await async_client.get(f"/teams/{team.id}/usage", headers=_auth(admin.id))
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        by_user = {r["user_id"]: r for r in rows}
+        assert str(member.id) in by_user
+        row = by_user[str(member.id)]
+        assert row["window_5h_used"] == 0.0
+        assert row["weekly_used"] == 0.0
+        assert row["extra_credits_month_to_date"] == 0.0
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_admin_topup_returns_checkout_url(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    _enable_revolut(monkeypatch, order_id=f"team_ord_{team.id}")
+    try:
+        # Non-admin member cannot open a team top-up.
+        resp = await async_client.post(
+            f"/teams/{team.id}/topup", json={"amount": 50.0}, headers=_auth(member.id)
+        )
+        assert resp.status_code == 403, resp.text
+
+        # Admin gets a checkout URL + a pending team credit transaction.
+        resp = await async_client.post(
+            f"/teams/{team.id}/topup", json={"amount": 50.0}, headers=_auth(admin.id)
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["checkout_url"] == "http://pay/team-checkout"
+        async with AsyncSessionLocal() as db:
+            tx = (
+                await db.execute(
+                    select(TeamCreditTransaction).where(TeamCreditTransaction.team_id == team.id)
+                )
+            ).scalar_one()
+            assert float(tx.amount) == 50.0
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+# ---------------------------------------------------------------- Member endpoints
+
+
+async def test_member_me_hides_balance_and_members(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    try:
+        resp = await async_client.get("/teams/me", headers=_auth(member.id))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["role"] == "member"
+        assert body["team"]["id"] == str(team.id)
+        assert body["balance"] is None
+        assert body["members"] is None
+
+        # Admin sees both.
+        resp = await async_client.get("/teams/me", headers=_auth(admin.id))
+        body = resp.json()
+        assert body["role"] == "admin"
+        assert body["balance"] is not None
+        assert body["members"] is not None
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_member_me_404_when_no_team(async_client, monkeypatch):
+    user = await _make_user()
+    try:
+        resp = await async_client.get("/teams/me", headers=_auth(user.id))
+        assert resp.status_code == 404
+    finally:
+        async with AsyncSessionLocal() as db:
+            await db.execute(delete(User).where(User.id == user.id))
+            await db.commit()
+
+
+async def test_member_cannot_admin_endpoints(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    _enable_revolut(monkeypatch, order_id=f"team_ord_forbidden_{team.id}")
+    h = _auth(member.id)
+    try:
+        assert (
+            await async_client.post(
+                f"/teams/{team.id}/invites", json={"email": "x@example.com"}, headers=h
+            )
+        ).status_code == 403
+        assert (
+            await async_client.post(
+                f"/teams/{team.id}/seats", json={"user_id": str(member.id), "tier": "plus"}, headers=h
+            )
+        ).status_code == 403
+        assert (await async_client.get(f"/teams/{team.id}/ledger", headers=h)).status_code == 403
+        assert (await async_client.get(f"/teams/{team.id}/usage", headers=h)).status_code == 403
+        assert (
+            await async_client.patch(
+                f"/teams/{team.id}/caps", json={"extra_credits_monthly_cap": 10.0}, headers=h
+            )
+        ).status_code == 403
+        assert (
+            await async_client.post(f"/teams/{team.id}/topup", json={"amount": 5.0}, headers=h)
+        ).status_code == 403
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_leave_team(async_client, monkeypatch):
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)
+    try:
+        resp = await async_client.post("/teams/leave", headers=_auth(member.id))
+        assert resp.status_code == 200, resp.text
+        async with AsyncSessionLocal() as db:
+            gone = (
+                await db.execute(select(TeamMembership).where(TeamMembership.user_id == member.id))
+            ).scalar_one_or_none()
+            assert gone is None
+
+        # The last admin cannot leave.
+        resp = await async_client.post("/teams/leave", headers=_auth(admin.id))
+        assert resp.status_code == 400, resp.text
+        assert "admin" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+# ---------------------------------------------------------------- IDOR
+
+
+async def test_team_b_admin_cannot_touch_team_a(async_client, monkeypatch):
+    team_a, admin_a = await _seed_team()
+    member_a = await _add_member(team_a.id)
+    team_b, admin_b = await _seed_team()
+    _enable_revolut(monkeypatch, order_id=f"idor_{team_a.id}")
+    hb = _auth(admin_b.id)  # admin of team B acting on team A
+    try:
+        assert (
+            await async_client.post(
+                f"/teams/{team_a.id}/invites", json={"email": "x@example.com"}, headers=hb
+            )
+        ).status_code == 403
+        assert (
+            await async_client.post(
+                f"/teams/{team_a.id}/seats", json={"user_id": str(member_a.id), "tier": "plus"}, headers=hb
+            )
+        ).status_code == 403
+        assert (
+            await async_client.patch(
+                f"/teams/{team_a.id}/seats/{member_a.id}", json={"tier": "max"}, headers=hb
+            )
+        ).status_code == 403
+        assert (
+            await async_client.delete(f"/teams/{team_a.id}/seats/{member_a.id}", headers=hb)
+        ).status_code == 403
+        assert (
+            await async_client.delete(f"/teams/{team_a.id}/members/{member_a.id}", headers=hb)
+        ).status_code == 403
+        assert (
+            await async_client.post(
+                f"/teams/{team_a.id}/members/{member_a.id}/role", json={"role": "admin"}, headers=hb
+            )
+        ).status_code == 403
+        assert (await async_client.get(f"/teams/{team_a.id}/ledger", headers=hb)).status_code == 403
+        assert (await async_client.get(f"/teams/{team_a.id}/usage", headers=hb)).status_code == 403
+        assert (
+            await async_client.patch(
+                f"/teams/{team_a.id}/caps", json={"extra_credits_monthly_cap": 1.0}, headers=hb
+            )
+        ).status_code == 403
+        assert (
+            await async_client.patch(
+                f"/teams/{team_a.id}/members/{member_a.id}/cap",
+                json={"extra_credits_cap_override": 1.0},
+                headers=hb,
+            )
+        ).status_code == 403
+        assert (
+            await async_client.post(f"/teams/{team_a.id}/topup", json={"amount": 5.0}, headers=hb)
+        ).status_code == 403
+        assert (
+            await async_client.delete(f"/teams/{team_a.id}/invites/{uuid.uuid4()}", headers=hb)
+        ).status_code == 403
+    finally:
+        await _cleanup(team_a.id, admin_a.id, member_a.id)
+        await _cleanup(team_b.id, admin_b.id)

--- a/tests/test_team_routes.py
+++ b/tests/test_team_routes.py
@@ -425,6 +425,59 @@ async def test_seat_holder_blocked_from_subscribe_and_upgrade(async_client, monk
         await _cleanup(team.id, admin.id, member.id)
 
 
+async def test_seatless_member_blocked_from_subscribe_and_upgrade(async_client, monkeypatch):
+    """A team member without a seat still cannot open a personal subscription."""
+    monkeypatch.setattr("src.routes.payments.payments.resolve_currency", lambda request: "USD")
+    revolut = payment_registry.get("revolut")
+    monkeypatch.setattr(revolut, "secret_key", "sk_test")
+    monkeypatch.setattr(revolut, "webhook_secret", "wsk_test")
+    team, admin = await _seed_team()
+    member = await _add_member(team.id)  # member, no seat assigned
+    h = _auth(member.id)
+    try:
+        resp = await async_client.post(
+            "/payments/subscribe", json={"provider": "revolut", "tier": "max"}, headers=h
+        )
+        assert resp.status_code == 400, resp.text
+        assert "team" in resp.json()["detail"].lower()
+        resp = await async_client.post(
+            "/payments/upgrade", json={"provider": "revolut", "tier": "max"}, headers=h
+        )
+        assert resp.status_code == 400, resp.text
+        assert "team" in resp.json()["detail"].lower()
+    finally:
+        await _cleanup(team.id, admin.id, member.id)
+
+
+async def test_staff_update_caps_null_clears_omitted_leaves(async_client, monkeypatch):
+    """staff PATCH: explicit null clears a cap; omitting caps leaves them unchanged."""
+    headers = _staff_headers(monkeypatch)
+    team, admin = await _seed_team(
+        extra_credits_monthly_cap=100.0, extra_credits_member_default_cap=20.0
+    )
+    try:
+        # Explicit null clears the monthly cap; omitted member cap is left untouched.
+        resp = await async_client.patch(
+            f"/teams/admin/{team.id}", json={"extra_credits_monthly_cap": None}, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        async with AsyncSessionLocal() as db:
+            t = (await db.execute(select(Team).where(Team.id == team.id))).scalar_one()
+            assert t.extra_credits_monthly_cap is None
+            assert t.extra_credits_member_default_cap == 20.0
+        # PATCH with neither cap present leaves both unchanged.
+        resp = await async_client.patch(
+            f"/teams/admin/{team.id}", json={"name": "Renamed"}, headers=headers
+        )
+        assert resp.status_code == 200, resp.text
+        async with AsyncSessionLocal() as db:
+            t = (await db.execute(select(Team).where(Team.id == team.id))).scalar_one()
+            assert t.extra_credits_monthly_cap is None
+            assert t.extra_credits_member_default_cap == 20.0
+    finally:
+        await _cleanup(team.id, admin.id)
+
+
 async def test_seat_holder_subscription_shows_team_name(async_client, monkeypatch):
     team, admin = await _seed_team()
     member = await _add_member(team.id)

--- a/tests/test_team_seat_guards.py
+++ b/tests/test_team_seat_guards.py
@@ -1,0 +1,77 @@
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.models.plan_subscription import PlanSubscription
+from src.models.team import Team
+from src.models.user import User
+from src.services.payments.credit_subscription import CreditSubscriptionService
+from src.services.payments.manager import PaymentManager
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+
+
+async def _user_with_seat(db, period_end=None) -> tuple[User, Team, PlanSubscription]:
+    user = User(email=f"{uuid.uuid4()}@test.dev")
+    team = Team(name="Acme")
+    db.add_all([user, team])
+    await db.flush()
+    seat = PlanSubscription(
+        user_id=user.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+        team_id=team.id, seat_price_snapshot=16.0,
+        current_period_start=datetime.now() - timedelta(days=40),
+        current_period_end=period_end or (datetime.now() - timedelta(days=10)),
+        cancel_at_period_end=True,
+    )
+    db.add(seat)
+    await db.flush()
+    return user, team, seat
+
+
+class _NoProvider:
+    """PaymentManager provider stub — must never be called for seats."""
+    id = "revolut"
+
+    def __getattr__(self, name):  # any provider call is a test failure
+        raise AssertionError(f"provider.{name} must not be called for team seats")
+
+
+@pytest.mark.asyncio
+async def test_active_subscription_ignores_seats(db):
+    user, _, _ = await _user_with_seat(db)
+    manager = PaymentManager(_NoProvider(), db)
+    assert await manager._active_subscription(user.id) is None
+
+
+@pytest.mark.asyncio
+async def test_manager_cancel_rejects_seat_holder(db):
+    user, _, seat = await _user_with_seat(db)
+    manager = PaymentManager(_NoProvider(), db)
+    with pytest.raises(ValueError):
+        await manager.cancel(user)
+    assert seat.status == "active"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_check_expirations_leaves_seats_alone(db):
+    # Seat past period end with cancel_at_period_end=True — exactly what the cron
+    # expires for personal subs. Team seats are owned by the team cron instead.
+    _, _, seat = await _user_with_seat(db)
+    manager = PaymentManager(_NoProvider(), db)
+    await manager.check_expirations()
+    assert seat.status == "active"
+
+
+@pytest.mark.asyncio
+async def test_process_renewals_ignores_seats(db):
+    _, _, seat = await _user_with_seat(db)
+    await CreditSubscriptionService.process_renewals(db)
+    assert seat.status == "active"  # provider filter already excludes team_credits
+
+
+@pytest.mark.asyncio
+async def test_credit_subscribe_blocked_by_seat(db):
+    # The one-live-sub guard treats a seat as the existing subscription.
+    user, _, _ = await _user_with_seat(db, period_end=datetime.now() + timedelta(days=10))
+    with pytest.raises(ValueError, match="active subscription"):
+        await CreditSubscriptionService.subscribe(db, user, "plus")

--- a/tests/test_team_seats.py
+++ b/tests/test_team_seats.py
@@ -97,6 +97,56 @@ async def test_downgrade_sets_pending_tier(db):
 
 
 @pytest.mark.asyncio
+async def test_change_tier_reactivates_cancelled_seat(db):
+    """Cancel then upgrade must clear cancel_at_period_end so the seat renews, not lapses."""
+    team, user, _ = await _team_with_member(db)
+    now = datetime(2026, 6, 16)
+    await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)
+    await TeamSeatService.cancel_seat(db, team, user.id)
+    seat = await TeamSeatService.change_tier(db, team, user.id, "max", now=now)
+    assert seat.cancel_at_period_end is False
+    assert seat.pending_tier is None and seat.tier == "max"
+
+    # Next renewal renews the seat (it is not expired).
+    await TeamSeatService.process_renewals(db, now=datetime(2026, 7, 1, 0, 30))
+    assert seat.status == "active"
+    assert seat.current_period_end == datetime(2026, 8, 1)
+
+
+@pytest.mark.asyncio
+async def test_change_tier_downgrade_reactivates_cancelled_seat(db):
+    """Cancel then downgrade-to-paid-tier also clears the cancel flag."""
+    team, user, _ = await _team_with_member(db)
+    now = datetime(2026, 6, 16)
+    await TeamSeatService.assign_seat(db, team, user.id, "max", now=now)
+    await TeamSeatService.cancel_seat(db, team, user.id)
+    seat = await TeamSeatService.change_tier(db, team, user.id, "plus", now=now)
+    assert seat.cancel_at_period_end is False
+    assert seat.tier == "max" and seat.pending_tier == "plus"
+
+    await TeamSeatService.process_renewals(db, now=datetime(2026, 7, 1, 0, 30))
+    assert seat.status == "active" and seat.tier == "plus"
+
+
+@pytest.mark.asyncio
+async def test_assign_seat_duplicate_raises_value_error(db):
+    """A personal active sub on the member surfaces as ValueError, not IntegrityError."""
+    from src.services.payments.credit_subscription import CREDITS_PROVIDER
+
+    team, user, _ = await _team_with_member(db)
+    # Give the member a live personal sub so the seat insert trips the one-live-sub index.
+    db.add(
+        PlanSubscription(
+            user_id=user.id, tier="plus", provider=CREDITS_PROVIDER, status="active", currency="USD",
+            current_period_start=datetime(2026, 6, 1), current_period_end=datetime(2026, 7, 1),
+        )
+    )
+    await db.flush()
+    with pytest.raises(ValueError, match="already has an active subscription or seat"):
+        await TeamSeatService.assign_seat(db, team, user.id, "plus", now=datetime(2026, 6, 16))
+
+
+@pytest.mark.asyncio
 async def test_renewal_aggregate_debit_and_roll(db):
     team, user, admin = await _team_with_member(db)
     now = datetime(2026, 6, 16)

--- a/tests/test_team_seats.py
+++ b/tests/test_team_seats.py
@@ -1,0 +1,179 @@
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from src.interfaces.credits import CreditTransactionProvider
+from src.models.plan_subscription import PlanSubscription
+from src.models.team_ledger_entry import TeamLedgerEntry
+from src.models.team_membership import ROLE_ADMIN, ROLE_MEMBER, TeamMembership
+from src.models.user import User
+from src.services.payments.team_seat_subscription import (
+    TEAM_CREDITS_PROVIDER,
+    TeamSeatService,
+    month_bounds,
+    prorated_price,
+)
+from src.services.team_credit import TeamCreditService
+from src.services.teams import TeamService
+
+
+async def _team_with_member(db, balance=1000.0, seat_prices=None):
+    team = await TeamService.create_team(db, "Acme", seat_prices=seat_prices or {"plus": 16.0, "max": 80.0})
+    user = User(email=f"{uuid.uuid4()}@test.dev")
+    admin = User(email=f"{uuid.uuid4()}@test.dev")
+    db.add_all([user, admin])
+    await db.flush()
+    db.add_all([
+        TeamMembership(team_id=team.id, user_id=user.id, role=ROLE_MEMBER),
+        TeamMembership(team_id=team.id, user_id=admin.id, role=ROLE_ADMIN),
+    ])
+    await db.flush()
+    if balance:
+        await TeamCreditService.add_credits(db, team.id, balance, CreditTransactionProvider.revolut)
+    return team, user, admin
+
+
+def test_prorated_price_includes_today():
+    # June has 30 days.
+    assert prorated_price(30.0, datetime(2026, 6, 1, 12)) == 30.0     # 1st = full month
+    assert prorated_price(30.0, datetime(2026, 6, 30, 12)) == 1.0     # last day = 1/30
+    assert prorated_price(30.0, datetime(2026, 6, 16, 0)) == 15.0     # 15 days left incl. today
+
+
+def test_month_bounds():
+    start, end = month_bounds(datetime(2026, 12, 31, 23, 59))
+    assert start == datetime(2026, 12, 1) and end == datetime(2027, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_assign_seat_charges_prorated_and_snapshots(db):
+    team, user, _ = await _team_with_member(db)
+    now = datetime(2026, 6, 16)  # 15/30 days left
+    seat = await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)
+
+    assert seat.provider == TEAM_CREDITS_PROVIDER and seat.status == "active"
+    assert seat.team_id == team.id and seat.seat_price_snapshot == 16.0
+    assert seat.current_period_end == datetime(2026, 7, 1)
+    assert await TeamCreditService.get_balance(db, team.id) == 1000.0 - 8.0
+    entry = (
+        await db.execute(select(TeamLedgerEntry).where(TeamLedgerEntry.team_id == team.id))
+    ).scalar_one()
+    assert entry.entry_type == "seat_charge_prorated" and entry.amount == 8.0
+
+
+@pytest.mark.asyncio
+async def test_assign_seat_requires_membership_funds_and_active_team(db):
+    team, user, _ = await _team_with_member(db, balance=1.0)
+    with pytest.raises(ValueError, match="Insufficient team balance"):
+        await TeamSeatService.assign_seat(db, team, user.id, "plus", now=datetime(2026, 6, 2))
+    outsider = User(email=f"{uuid.uuid4()}@test.dev")
+    db.add(outsider)
+    await db.flush()
+    with pytest.raises(ValueError, match="not a member"):
+        await TeamSeatService.assign_seat(db, team, outsider.id, "plus")
+    team.status = "suspended"
+    with pytest.raises(ValueError, match="suspended"):
+        await TeamSeatService.assign_seat(db, team, user.id, "plus")
+
+
+@pytest.mark.asyncio
+async def test_upgrade_charges_prorated_difference(db):
+    team, user, _ = await _team_with_member(db)
+    now = datetime(2026, 6, 16)
+    await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)  # -8.0
+    seat = await TeamSeatService.change_tier(db, team, user.id, "max", now=now)  # +(80-16)*0.5 = 32.0
+    assert seat.tier == "max" and seat.seat_price_snapshot == 80.0
+    assert await TeamCreditService.get_balance(db, team.id) == 1000.0 - 8.0 - 32.0
+
+
+@pytest.mark.asyncio
+async def test_downgrade_sets_pending_tier(db):
+    team, user, _ = await _team_with_member(db)
+    await TeamSeatService.assign_seat(db, team, user.id, "max", now=datetime(2026, 6, 2))
+    seat = await TeamSeatService.change_tier(db, team, user.id, "plus", now=datetime(2026, 6, 10))
+    assert seat.tier == "max" and seat.pending_tier == "plus"
+
+
+@pytest.mark.asyncio
+async def test_renewal_aggregate_debit_and_roll(db):
+    team, user, admin = await _team_with_member(db)
+    now = datetime(2026, 6, 16)
+    await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)
+    await TeamSeatService.assign_seat(db, team, admin.id, "max", now=now)
+    balance_before = await TeamCreditService.get_balance(db, team.id)
+
+    processed, notices = await TeamSeatService.process_renewals(db, now=datetime(2026, 7, 1, 0, 30))
+    assert processed == 2 and notices == []
+    assert await TeamCreditService.get_balance(db, team.id) == balance_before - 96.0  # 16 + 80
+    seats = (
+        await db.execute(select(PlanSubscription).where(PlanSubscription.team_id == team.id))
+    ).scalars().all()
+    for seat in seats:
+        assert seat.status == "active"
+        assert seat.current_period_start == datetime(2026, 7, 1)
+        assert seat.current_period_end == datetime(2026, 8, 1)
+    renewal = (
+        await db.execute(
+            select(TeamLedgerEntry).where(
+                TeamLedgerEntry.team_id == team.id, TeamLedgerEntry.entry_type == "monthly_renewal"
+            )
+        )
+    ).scalar_one()
+    assert renewal.amount == 96.0  # single aggregate statement line
+
+
+@pytest.mark.asyncio
+async def test_renewal_honors_cancel_and_pending_tier(db):
+    team, user, admin = await _team_with_member(db)
+    now = datetime(2026, 6, 16)
+    s1 = await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)
+    s2 = await TeamSeatService.assign_seat(db, team, admin.id, "max", now=now)
+    await TeamSeatService.cancel_seat(db, team, user.id)
+    await TeamSeatService.change_tier(db, team, admin.id, "plus", now=now)  # downgrade pending
+
+    balance_before = await TeamCreditService.get_balance(db, team.id)
+    await TeamSeatService.process_renewals(db, now=datetime(2026, 7, 1, 0, 30))
+
+    assert s1.status == "expired"
+    assert s2.status == "active" and s2.tier == "plus" and s2.pending_tier is None
+    assert s2.seat_price_snapshot == 16.0
+    assert await TeamCreditService.get_balance(db, team.id) == balance_before - 16.0
+
+
+@pytest.mark.asyncio
+async def test_renewal_shortfall_expires_all_and_notifies(db):
+    team, user, admin = await _team_with_member(db, balance=0.0)
+    now = datetime(2026, 6, 16)
+    await TeamCreditService.add_credits(db, team.id, 48.5, CreditTransactionProvider.revolut)
+    await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)   # -8
+    await TeamSeatService.assign_seat(db, team, admin.id, "max", now=now)   # -40  -> 0.5 left
+
+    processed, notices = await TeamSeatService.process_renewals(db, now=datetime(2026, 7, 1, 0, 30))
+    assert processed == 2
+    seats = (
+        await db.execute(select(PlanSubscription).where(PlanSubscription.team_id == team.id))
+    ).scalars().all()
+    assert all(s.status == "expired" for s in seats)
+    assert await TeamCreditService.get_balance(db, team.id) == 0.5  # nothing partially charged
+    assert len(notices) == 1
+    assert notices[0]["team_id"] == team.id and admin.email in notices[0]["admin_emails"]
+
+
+@pytest.mark.asyncio
+async def test_renewal_reanchors_after_long_downtime(db):
+    team, user, _ = await _team_with_member(db)
+    seat = await TeamSeatService.assign_seat(db, team, user.id, "plus", now=datetime(2026, 6, 16))
+    # Cron dead for > a full cycle: re-anchor at the current month, no back-billing.
+    await TeamSeatService.process_renewals(db, now=datetime(2026, 9, 10))
+    assert seat.current_period_start == datetime(2026, 9, 1)
+    assert seat.current_period_end == datetime(2026, 10, 1)
+
+
+@pytest.mark.asyncio
+async def test_suspend_team_expires_seats(db):
+    team, user, _ = await _team_with_member(db)
+    seat = await TeamSeatService.assign_seat(db, team, user.id, "plus", now=datetime(2026, 6, 2))
+    await TeamSeatService.suspend_team(db, team)
+    assert team.status == "suspended" and seat.status == "expired"

--- a/tests/test_team_seats.py
+++ b/tests/test_team_seats.py
@@ -162,6 +162,25 @@ async def test_renewal_shortfall_expires_all_and_notifies(db):
 
 
 @pytest.mark.asyncio
+async def test_renewal_falls_back_to_snapshot_when_tier_dropped(db):
+    # A non-empty price map that no longer sells the seat's tier must not wedge the
+    # renewal — it falls back to the seat's snapshot price and renews normally.
+    team, user, _ = await _team_with_member(db)
+    now = datetime(2026, 6, 16)
+    seat = await TeamSeatService.assign_seat(db, team, user.id, "plus", now=now)
+    assert seat.seat_price_snapshot == 16.0
+    team.seat_prices = {"max": 80.0}  # "plus" dropped, map still non-empty
+    await db.flush()
+
+    balance_before = await TeamCreditService.get_balance(db, team.id)
+    processed, notices = await TeamSeatService.process_renewals(db, now=datetime(2026, 7, 1, 0, 30))
+    assert processed == 1 and notices == []
+    assert seat.status == "active" and seat.tier == "plus"
+    assert seat.seat_price_snapshot == 16.0  # snapshot preserved
+    assert await TeamCreditService.get_balance(db, team.id) == balance_before - 16.0
+
+
+@pytest.mark.asyncio
 async def test_renewal_reanchors_after_long_downtime(db):
     team, user, _ = await _team_with_member(db)
     seat = await TeamSeatService.assign_seat(db, team, user.id, "plus", now=datetime(2026, 6, 16))

--- a/tests/test_team_topup.py
+++ b/tests/test_team_topup.py
@@ -95,3 +95,39 @@ async def test_settle_fails_team_topup_on_failed_order(db):
         )
     ).scalar_one()
     assert tx.status == CreditTransactionStatus.error and tx.is_active is False and tx.amount_left == 0
+
+
+@pytest.mark.asyncio
+async def test_out_of_order_failed_does_not_zero_completed_team_topup(db):
+    """An order_failed arriving after completion must not erase a spendable balance."""
+    team = await TeamService.create_team(db, "Acme")
+    manager = PaymentManager(_FakeProvider(), db)
+    await manager.start_team_topup(team, admin_email=None, redirect_url="https://app/cb", usd_credits=150.0)
+
+    # Complete first.
+    await manager._settle_topup(
+        PaymentEvent(
+            provider="revolut",
+            type=PaymentEventType.order_completed,
+            provider_event_id=f"ORDER_COMPLETED:order-123:{uuid.uuid4()}",
+            order_id="order-123",
+        )
+    )
+    assert await TeamCreditService.get_balance(db, team.id) == 150.0
+
+    # A late failed event must be ignored — balance and status unchanged.
+    await manager._settle_topup(
+        PaymentEvent(
+            provider="revolut",
+            type=PaymentEventType.order_failed,
+            provider_event_id=f"ORDER_FAILED:order-123:{uuid.uuid4()}",
+            order_id="order-123",
+        )
+    )
+    tx = (
+        await db.execute(
+            select(TeamCreditTransaction).where(TeamCreditTransaction.team_id == team.id)
+        )
+    ).scalar_one()
+    assert tx.status == CreditTransactionStatus.completed and tx.is_active is True
+    assert await TeamCreditService.get_balance(db, team.id) == 150.0

--- a/tests/test_team_topup.py
+++ b/tests/test_team_topup.py
@@ -1,0 +1,97 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from src.interfaces.credits import CreditTransactionStatus
+from src.models.team_credit_transaction import TeamCreditTransaction
+from src.services.payments.base import CheckoutResult, PaymentEvent, PaymentEventType
+from src.services.payments.manager import PaymentManager
+from src.services.team_credit import TeamCreditService
+from src.services.teams import TeamService
+
+
+class _FakeProvider:
+    id = "revolut"
+
+    def supports(self, capability):
+        return True
+
+    async def create_topup(self, **kwargs):
+        self.last_topup = kwargs
+        return CheckoutResult(checkout_url="https://pay.example/x", order_id="order-123")
+
+
+@pytest.mark.asyncio
+async def test_start_team_topup_creates_pending_team_row(db):
+    team = await TeamService.create_team(db, "Acme")
+    provider = _FakeProvider()
+    manager = PaymentManager(provider, db)
+
+    result = await manager.start_team_topup(
+        team, admin_email="admin@corp.dev", redirect_url="https://app/cb", usd_credits=200.0
+    )
+
+    assert result.order_id == "order-123"
+    tx = (
+        await db.execute(
+            select(TeamCreditTransaction).where(TeamCreditTransaction.team_id == team.id)
+        )
+    ).scalar_one()
+    assert tx.status == CreditTransactionStatus.pending
+    assert tx.amount == 200.0
+    assert tx.external_reference == "revolut:order-123"
+    assert provider.last_topup["metadata"]["ext_ref"] == f"topup:team:{team.id}"
+    # Pending rows don't count toward the balance.
+    assert await TeamCreditService.get_balance(db, team.id) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_settle_completes_team_topup(db):
+    team = await TeamService.create_team(db, "Acme")
+    provider = _FakeProvider()
+    manager = PaymentManager(provider, db)
+    await manager.start_team_topup(team, admin_email=None, redirect_url="https://app/cb", usd_credits=150.0)
+
+    handled = await manager._settle_topup(
+        PaymentEvent(
+            provider="revolut",
+            type=PaymentEventType.order_completed,
+            provider_event_id=f"ORDER_COMPLETED:order-123:{uuid.uuid4()}",
+            order_id="order-123",
+        )
+    )
+    assert handled is True
+    assert await TeamCreditService.get_balance(db, team.id) == 150.0
+    # Replay is idempotent.
+    await manager._settle_topup(
+        PaymentEvent(
+            provider="revolut",
+            type=PaymentEventType.order_completed,
+            provider_event_id=f"ORDER_COMPLETED:order-123:{uuid.uuid4()}",
+            order_id="order-123",
+        )
+    )
+    assert await TeamCreditService.get_balance(db, team.id) == 150.0
+
+
+@pytest.mark.asyncio
+async def test_settle_fails_team_topup_on_failed_order(db):
+    team = await TeamService.create_team(db, "Acme")
+    manager = PaymentManager(_FakeProvider(), db)
+    await manager.start_team_topup(team, admin_email=None, redirect_url="https://app/cb", usd_credits=150.0)
+
+    await manager._settle_topup(
+        PaymentEvent(
+            provider="revolut",
+            type=PaymentEventType.order_failed,
+            provider_event_id=f"ORDER_FAILED:order-123:{uuid.uuid4()}",
+            order_id="order-123",
+        )
+    )
+    tx = (
+        await db.execute(
+            select(TeamCreditTransaction).where(TeamCreditTransaction.team_id == team.id)
+        )
+    ).scalar_one()
+    assert tx.status == CreditTransactionStatus.error and tx.is_active is False and tx.amount_left == 0

--- a/tests/test_teams_service.py
+++ b/tests/test_teams_service.py
@@ -1,0 +1,93 @@
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from src.models.plan_subscription import PlanSubscription
+from src.models.plan_subscription_event import PlanSubscriptionEvent
+from src.models.team_membership import ROLE_ADMIN, ROLE_MEMBER, TeamMembership
+from src.models.user import User
+from src.services.payments.team_seat_subscription import TEAM_CREDITS_PROVIDER
+from src.services.teams import TeamService
+
+
+async def _setup(db, n_members=2):
+    team = await TeamService.create_team(db, "Acme", seat_prices={"plus": 16.0, "max": 80.0})
+    users = []
+    for i in range(n_members):
+        u = User(email=f"{uuid.uuid4()}@test.dev")
+        db.add(u)
+        await db.flush()
+        db.add(TeamMembership(team_id=team.id, user_id=u.id, role=ROLE_ADMIN if i == 0 else ROLE_MEMBER))
+        users.append(u)
+    await db.flush()
+    return team, users
+
+
+@pytest.mark.asyncio
+async def test_create_team_validates_seat_prices(db):
+    with pytest.raises(ValueError, match="Unknown tier"):
+        await TeamService.create_team(db, "Bad", seat_prices={"platinum": 50.0})
+    with pytest.raises(ValueError, match="positive"):
+        await TeamService.create_team(db, "Bad", seat_prices={"plus": 0})
+
+
+@pytest.mark.asyncio
+async def test_seat_price_negotiated_vs_list_vs_unsellable(db):
+    team, _ = await _setup(db)
+    assert TeamService.seat_price(team, "plus") == 16.0
+    with pytest.raises(ValueError, match="not sold"):
+        TeamService.seat_price(team, "go")  # non-empty map without "go"
+    empty = await TeamService.create_team(db, "ListPrices")
+    assert TeamService.seat_price(empty, "plus") == 20.0  # list price
+
+
+@pytest.mark.asyncio
+async def test_require_membership_and_admin(db):
+    team, (admin, member) = await _setup(db)
+    outsider = User(email=f"{uuid.uuid4()}@test.dev")
+    db.add(outsider)
+    await db.flush()
+    assert (await TeamService.require_membership(db, team.id, admin.id, admin=True)).role == ROLE_ADMIN
+    with pytest.raises(PermissionError):
+        await TeamService.require_membership(db, team.id, member.id, admin=True)
+    with pytest.raises(PermissionError):
+        await TeamService.require_membership(db, team.id, outsider.id)
+
+
+@pytest.mark.asyncio
+async def test_last_admin_cannot_demote_or_leave(db):
+    team, (admin, member) = await _setup(db)
+    with pytest.raises(ValueError, match="last admin"):
+        await TeamService.set_role(db, team.id, admin.id, admin.id, ROLE_MEMBER)
+    with pytest.raises(ValueError, match="last admin"):
+        await TeamService.leave(db, admin.id)
+    # Promote the member, then the original admin may demote/leave.
+    await TeamService.set_role(db, team.id, admin.id, member.id, ROLE_ADMIN)
+    await TeamService.leave(db, admin.id)
+    assert await TeamService.get_membership(db, admin.id) is None
+
+
+@pytest.mark.asyncio
+async def test_remove_member_expires_seat_and_logs_actor(db):
+    team, (admin, member) = await _setup(db)
+    seat = PlanSubscription(
+        user_id=member.id, tier="plus", provider=TEAM_CREDITS_PROVIDER, status="active",
+        team_id=team.id, seat_price_snapshot=16.0,
+        current_period_start=datetime.now(), current_period_end=datetime.now() + timedelta(days=10),
+    )
+    db.add(seat)
+    await db.flush()
+
+    await TeamService.remove_member(db, team.id, member.id, removed_by=admin.id)
+
+    assert await TeamService.get_membership(db, member.id) is None
+    assert seat.status == "expired"
+    event = (
+        await db.execute(
+            select(PlanSubscriptionEvent).where(PlanSubscriptionEvent.subscription_id == seat.id)
+        )
+    ).scalars().first()
+    assert event.event_type == "member_removed"
+    assert event.metadata_json["removed_by"] == str(admin.id)

--- a/tests/test_teams_service.py
+++ b/tests/test_teams_service.py
@@ -91,3 +91,10 @@ async def test_remove_member_expires_seat_and_logs_actor(db):
     ).scalars().first()
     assert event.event_type == "member_removed"
     assert event.metadata_json["removed_by"] == str(admin.id)
+
+
+@pytest.mark.asyncio
+async def test_set_role_requires_admin_actor(db):
+    team, (admin, member) = await _setup(db)
+    with pytest.raises(PermissionError):
+        await TeamService.set_role(db, team.id, member.id, admin.id, ROLE_MEMBER)


### PR DESCRIPTION
## Summary

Sales-led **Teams**: LibertAI staff provision a team with negotiated per-tier seat pricing; team admins invite members, assign per-seat subscriptions (mixed tiers), and fund a **team credit balance** on-platform that pays seat renewals and capped **extra-credits** usage. Each member keeps their own private 5h/weekly entitlement windows.

Spec: `docs/superpowers/specs/2026-07-04-teams-design.md` (not committed — available on request).

## Architecture

- **Seats are `plan_subscriptions` rows** with `provider="team_credits"` (+ `team_id`, `seat_price_snapshot`): tier resolution/entitlement windows needed zero changes; the one-active-sub index blocks personal+seat conflicts; the events table gives seat audit for free.
- **Team balance** (`team_credit_transactions`, drained oldest-first) funds everything — no Revolut plans for teams. Top-ups reuse the one-off order flow; debits recorded in `team_ledger_entries`.
- **Calendar-month billing (UTC)**: mid-month assigns prorated by remaining days; an hourly-sweep cron renews each team's seats with ONE aggregate debit, all-or-nothing (shortfall → all seats expire + admins emailed).
- **Extra credits**: post-window usage drains the team balance in the same transaction as the usage row, gated by team + per-member monthly caps (default 0 = off; unit = `credits_used - tier_credits_used`).
- **Join guard**: verified matching email, no active personal sub, zero personal balance; members are blocked from personal top-ups/vouchers/subscribe/upgrade while in a team.
- Personal payment surface fully fenced: `_active_subscription`, `check_expirations`, and all personal sub mutations exclude/reject team seats.

## Review process

Built task-by-task with per-task spec+quality reviews, a whole-branch final review (8 findings fixed, incl. a critical renewal wedge on renegotiated pricing), and a 3-agent verification wave (bugs / security / concurrency — 8 more findings fixed, incl. seatless-member subscribe gap and a suspend/renewal lock-order inversion). Money paths verified: exactly-once renewals under cron overlap, idempotent webhook settles, atomic drain+ledger, full cross-team IDOR matrix.

## Deploy notes

- Alembic migration `0b8ab94fc7d8`: 5 new tables + 3 columns; the `inference_calls` index builds CONCURRENTLY (autocommit block).
- New hourly cron `renew_team_seats` (in-process APScheduler, row-lock safe across replicas) — worth an ops alert on repeated failures, like the existing renewal cron.
- No behavior change for existing personal-billing users (regression suites untouched and green).

## Test plan

- [x] 327 tests green (83 new across models, balance service, seat guards, teams/invites, top-ups, seat lifecycle, extra-credits gating, routes/authz incl. IDOR matrix)
- [x] ruff + mypy clean (0 new errors)
- [x] Migration up/down/up verified against Postgres