### PR TITLE
Staff backoffice: auth flag, gated stats, WAU/MAU, subscriptions revenue/churn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,6 @@ ADMIN_SECRET=  # Generate a secure random key using: python -c "import secrets; 
 # Allow localhost:5173 / :3000 as CORS + magic-link redirect targets (set True for local frontend dev)
 ALLOW_LOCALHOST_FRONTENDS=False
 
-VOUCHERS_PASSWORDS='["password1", "password2"]'
-
 # -- Aleph --
 # Use the testnet in development
 #ALEPH_API_URL=https://api.twentysix.testnet.network

--- a/alembic/versions/a78cc4205d8d_users_is_libertai_staff.py
+++ b/alembic/versions/a78cc4205d8d_users_is_libertai_staff.py
@@ -1,0 +1,27 @@
+"""users.is_libertai_staff (backoffice access flag)
+
+Revision ID: a78cc4205d8d
+Revises: c4f1a9d2e7b8
+Create Date: 2026-07-06
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a78cc4205d8d"
+down_revision: Union[str, None] = "c4f1a9d2e7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("is_libertai_staff", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_libertai_staff")

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 
@@ -28,7 +27,6 @@ class _Config:
 
     ADMIN_SECRET: str
     LIBERCLAW_SECRET: str
-    VOUCHERS_PASSWORDS: list[str]
 
     ALEPH_API_URL: str | None
     ALEPH_SENDER: str
@@ -114,7 +112,6 @@ class _Config:
 
         self.ADMIN_SECRET = os.getenv("ADMIN_SECRET", "")
         self.LIBERCLAW_SECRET: str = os.getenv("LIBERCLAW_SECRET", "")
-        self.VOUCHERS_PASSWORDS = json.loads(os.environ["VOUCHERS_PASSWORDS"])
 
         self.ALEPH_API_URL = os.getenv("ALEPH_API_URL")
         self.ALEPH_SENDER = os.getenv("ALEPH_SENDER")

--- a/src/interfaces/auth.py
+++ b/src/interfaces/auth.py
@@ -85,6 +85,7 @@ class CurrentUserResponse(BaseModel):
     display_name: str | None = None
     avatar_url: str | None = None
     address: str | None = None
+    is_libertai_staff: bool = False
 
 
 class UpdateProfileRequest(BaseModel):

--- a/src/interfaces/credits.py
+++ b/src/interfaces/credits.py
@@ -124,7 +124,6 @@ class ThirdwebOnrampTransactionData(BaseModel):
 class VoucherAddCreditsRequest(BaseModel):
     amount: Annotated[float, Field(gt=0)]
     expired_at: datetime | None = None
-    password: str
     # Exactly one recipient: a wallet (chain + address) or an email account.
     chain: LibertaiChain | None = None
     address: str | None = None
@@ -140,11 +139,6 @@ class VoucherAddCreditsRequest(BaseModel):
         if not is_address_valid(chain, value):
             raise ValueError(f"Invalid address for chain {chain}")
         return value
-
-    @field_validator("password")
-    def valid_password(cls, password):
-        if password not in config.VOUCHERS_PASSWORDS:
-            raise ValueError("Given password isn't in the list of allowed passwords.")
 
     @model_validator(mode="after")
     def exactly_one_recipient(self):

--- a/src/interfaces/credits.py
+++ b/src/interfaces/credits.py
@@ -7,8 +7,6 @@ from libertai_utils.chains.index import is_address_valid
 from libertai_utils.interfaces.blockchain import LibertaiChain
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
-from src.config import config
-
 
 class CreditTransactionProvider(str, Enum):
     ltai_base = "ltai_base"  # LTAI Base payments
@@ -160,7 +158,6 @@ class VoucherCreditsResponse(BaseModel):
 class GetVouchersRequest(BaseModel):
     chain: LibertaiChain
     address: str
-    password: str
 
     @field_validator("address")
     def validate_address(cls, value, info: ValidationInfo):
@@ -169,18 +166,7 @@ class GetVouchersRequest(BaseModel):
             raise ValueError(f"Invalid address for chain {chain}")
         return value
 
-    @field_validator("password")
-    def valid_password(cls, password):
-        if password not in config.VOUCHERS_PASSWORDS:
-            raise ValueError("Given password isn't in the list of allowed passwords.")
-
 
 class VoucherChangeExpireRequest(BaseModel):
     voucher_id: str
     expired_at: datetime | None
-    password: str
-
-    @field_validator("password")
-    def valid_password(cls, password):
-        if password not in config.VOUCHERS_PASSWORDS:
-            raise ValueError("Given password isn't in the list of allowed passwords.")

--- a/src/interfaces/stats.py
+++ b/src/interfaces/stats.py
@@ -234,3 +234,25 @@ class GlobalSubscribersOverTimeStats(BaseModel):
     """
 
     daily: list[TierSubscribersDay]
+
+
+class LatestSubscriber(BaseModel):
+    """A single recent plan subscription with a human-friendly label for its user.
+
+    ``user_label`` resolution order: email > display_name > wallet address > user id.
+    """
+
+    user_label: str
+    tier: str
+    status: str
+    provider: str
+    is_trial: bool
+    cancel_at_period_end: bool
+    created_at: str  # ISO date-time
+    current_period_end: str | None
+
+
+class GlobalLatestSubscribersStats(BaseModel):
+    """Most recent plan subscriptions across all providers, newest first."""
+
+    subscribers: list[LatestSubscriber]

--- a/src/interfaces/stats.py
+++ b/src/interfaces/stats.py
@@ -274,3 +274,19 @@ class GlobalSubscriptionsRevenueStats(BaseModel):
     current_mrr: float
     mrr_by_tier: list[MrrByTier]
     daily: list[MrrDay]
+
+
+class ChurnWeek(BaseModel):
+    week_start: str  # Monday, YYYY-MM-DD
+    new: int
+    churned: int
+    net: int
+
+
+class GlobalSubscriptionsChurnStats(BaseModel):
+    """Revolut, non-trial. new = first activations (upgrade replacements excluded);
+    churned = real terminations (cancelled/expired/finished; upgrades excluded)."""
+
+    weekly: list[ChurnWeek]
+    total_new: int
+    total_churned: int

--- a/src/interfaces/stats.py
+++ b/src/interfaces/stats.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from pydantic import BaseModel
 
 
@@ -143,6 +145,18 @@ class GlobalUsersStats(BaseModel):
 
     total_unique_users: int
     daily_active_users: list[DailyActiveUsers]
+
+
+class UsersWindow(str, Enum):
+    """Rolling window for active-user counts: DAU (day), WAU (week), MAU (month)."""
+
+    day = "day"
+    week = "week"
+    month = "month"
+
+    @property
+    def days(self) -> int:
+        return {"day": 1, "week": 7, "month": 30}[self.value]
 
 
 class SegmentMessageUsage(BaseModel):

--- a/src/interfaces/stats.py
+++ b/src/interfaces/stats.py
@@ -256,3 +256,21 @@ class GlobalLatestSubscribersStats(BaseModel):
     """Most recent plan subscriptions across all providers, newest first."""
 
     subscribers: list[LatestSubscriber]
+
+
+class MrrByTier(BaseModel):
+    tier: str
+    mrr: float
+
+
+class MrrDay(BaseModel):
+    date: str
+    mrr: float
+
+
+class GlobalSubscriptionsRevenueStats(BaseModel):
+    """Revolut (fiat) MRR, nominal and currency-blind; trials excluded. Event-replayed history."""
+
+    current_mrr: float
+    mrr_by_tier: list[MrrByTier]
+    daily: list[MrrDay]

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -25,6 +25,8 @@ class User(Base):
     display_name: Mapped[str | None] = mapped_column(String, nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
+    # Grants access to the staff backoffice (analytics + admin actions). Set manually via SQL.
+    is_libertai_staff: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Legacy wallet address. Identity moved to wallet_connections; kept (nullable, unique) for one
     # release as a rollback hatch and so existing address-based FKs resolve until the FK swap.

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -158,6 +158,7 @@ async def get_me(user: User = Depends(get_current_user)) -> CurrentUserResponse:
         display_name=user.display_name,
         avatar_url=user.avatar_url,
         address=user.address,
+        is_libertai_staff=user.is_libertai_staff,
     )
 
 
@@ -175,6 +176,7 @@ async def update_me(
             display_name=updated.display_name,
             avatar_url=updated.avatar_url,
             address=updated.address,
+            is_libertai_staff=updated.is_libertai_staff,
         )
 
 

--- a/src/routes/credits/voucher.py
+++ b/src/routes/credits/voucher.py
@@ -49,11 +49,15 @@ async def add_voucher_credits(voucher_request: VoucherAddCreditsRequest) -> bool
     )
 
 
-@router.get("/vouchers", description="Get all vouchers for a specific address")  # type: ignore
-async def get_vouchers(chain: LibertaiChain, address: str, password: str) -> list[VoucherCreditsResponse]:
+@router.get(  # type: ignore
+    "/vouchers",
+    description="[staff] Get all vouchers for a specific address",
+    dependencies=[Depends(require_staff)],
+)
+async def get_vouchers(chain: LibertaiChain, address: str) -> list[VoucherCreditsResponse]:
     # Validate input using Pydantic model
     try:
-        params = GetVouchersRequest(chain=chain, address=address, password=password)
+        params = GetVouchersRequest(chain=chain, address=address)
     except ValueError as e:
         # This explicitly raises the validation error to be handled by FastAPI
         raise HTTPException(status_code=400, detail=str(e))
@@ -76,7 +80,11 @@ async def get_vouchers(chain: LibertaiChain, address: str, password: str) -> lis
     ]
 
 
-@router.post("/voucher/expiration", description="Change a voucher's expiration date")  # type: ignore
+@router.post(  # type: ignore
+    "/voucher/expiration",
+    description="[staff] Change a voucher's expiration date",
+    dependencies=[Depends(require_staff)],
+)
 async def change_voucher_expiration(request: VoucherChangeExpireRequest) -> bool:
     # Convert string to UUID to ensure it's valid
     try:

--- a/src/routes/credits/voucher.py
+++ b/src/routes/credits/voucher.py
@@ -21,11 +21,11 @@ from src.utils.logger import setup_logger
 logger = setup_logger(__name__)
 
 
-@router.post(
+@router.post(  # type: ignore
     "/vouchers",
     description="[staff] Add credits via voucher to a wallet address or an email account",
     dependencies=[Depends(require_staff)],
-)  # type: ignore
+)
 async def add_voucher_credits(voucher_request: VoucherAddCreditsRequest) -> bool:
     if voucher_request.email is not None:
         # Existing email account only — never create one from a voucher. Credit by user id, no wallet.

--- a/src/routes/credits/voucher.py
+++ b/src/routes/credits/voucher.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import HTTPException
+from fastapi import Depends, HTTPException
 from libertai_utils.chains.index import format_address
 from libertai_utils.interfaces.blockchain import LibertaiChain
 
@@ -13,6 +13,7 @@ from src.interfaces.credits import (
 )
 from src.models.base import AsyncSessionLocal
 from src.routes.credits import router
+from src.services.auth import require_staff
 from src.services.credit import CreditService
 from src.services.users import get_user_by_email
 from src.utils.logger import setup_logger
@@ -20,7 +21,11 @@ from src.utils.logger import setup_logger
 logger = setup_logger(__name__)
 
 
-@router.post("/vouchers", description="Add credits via voucher to a wallet address or an email account")  # type: ignore
+@router.post(
+    "/vouchers",
+    description="[staff] Add credits via voucher to a wallet address or an email account",
+    dependencies=[Depends(require_staff)],
+)  # type: ignore
 async def add_voucher_credits(voucher_request: VoucherAddCreditsRequest) -> bool:
     if voucher_request.email is not None:
         # Existing email account only — never create one from a voucher. Credit by user id, no wallet.

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -20,6 +20,7 @@ from src.interfaces.stats import (
     GlobalSubscribersOverTimeStats,
     GlobalLatestSubscribersStats,
     GlobalSubscriptionsRevenueStats,
+    GlobalSubscriptionsChurnStats,
 )
 from src.models.user import User
 from src.routes.stats import router
@@ -122,6 +123,22 @@ async def get_subscriptions_revenue(
         return await StatsService.get_global_subscriptions_revenue(start_date, end_date)
     except Exception as e:
         logger.error(f"Error in subscriptions revenue route: {str(e)}", exc_info=True)
+        raise
+
+
+@router.get(
+    "/global/subscriptions/churn",
+    response_model=GlobalSubscriptionsChurnStats,
+    dependencies=[Depends(require_staff)],
+)  # type: ignore
+async def get_subscriptions_churn(
+    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
+    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
+) -> GlobalSubscriptionsChurnStats:
+    try:
+        return await StatsService.get_global_subscriptions_churn(start_date, end_date)
+    except Exception as e:
+        logger.error(f"Error in subscriptions churn route: {str(e)}", exc_info=True)
         raise
 
 

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -18,6 +18,7 @@ from src.interfaces.stats import (
     GlobalCreditsConsumptionStats,
     GlobalSubscriptionsStats,
     GlobalSubscribersOverTimeStats,
+    GlobalLatestSubscribersStats,
 )
 from src.models.user import User
 from src.routes.stats import router
@@ -89,6 +90,21 @@ async def get_chat_users_stats(
         return await StatsService.get_global_chat_users_stats(start_date, end_date, window)
     except Exception as e:
         logger.error(f"Error in chat users stats route: {str(e)}", exc_info=True)
+        raise
+
+
+@router.get(
+    "/global/subscriptions/latest",
+    response_model=GlobalLatestSubscribersStats,
+    dependencies=[Depends(require_staff)],
+)  # type: ignore
+async def get_latest_subscribers(
+    limit: int = Query(20, ge=1, le=200, description="Number of most recent subscriptions to return"),
+) -> GlobalLatestSubscribersStats:
+    try:
+        return await StatsService.get_latest_subscribers(limit)
+    except Exception as e:
+        logger.error(f"Error in latest subscribers route: {str(e)}", exc_info=True)
         raise
 
 

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -20,7 +20,7 @@ from src.interfaces.stats import (
 )
 from src.models.user import User
 from src.routes.stats import router
-from src.services.auth import get_current_user
+from src.services.auth import get_current_user, require_staff
 from src.services.stats import StatsService
 from src.utils.logger import setup_logger
 
@@ -54,7 +54,7 @@ async def get_usage_stats(
 # Registered before the generic /global/{key_type}/... routes below.
 
 
-@router.get("/global/chat/calls", response_model=GlobalChatCallsStats)  # type: ignore
+@router.get("/global/chat/calls", response_model=GlobalChatCallsStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_chat_calls_stats(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -66,7 +66,7 @@ async def get_chat_calls_stats(
         raise
 
 
-@router.get("/global/chat/tokens", response_model=GlobalChatTokensStats)  # type: ignore
+@router.get("/global/chat/tokens", response_model=GlobalChatTokensStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_chat_tokens_stats(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -78,7 +78,7 @@ async def get_chat_tokens_stats(
         raise
 
 
-@router.get("/global/chat/users", response_model=GlobalUsersStats)  # type: ignore
+@router.get("/global/chat/users", response_model=GlobalUsersStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_chat_users_stats(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -93,7 +93,7 @@ async def get_chat_users_stats(
 # --- Generic inference stats: one set of routes for api / liberclaw / x402 / cli ---
 
 
-@router.get("/global/{key_type}/calls", response_model=GlobalApiStats)  # type: ignore
+@router.get("/global/{key_type}/calls", response_model=GlobalApiStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_inference_calls_stats(
     key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
@@ -106,7 +106,7 @@ async def get_inference_calls_stats(
         raise
 
 
-@router.get("/global/{key_type}/tokens", response_model=GlobalTokensStats)  # type: ignore
+@router.get("/global/{key_type}/tokens", response_model=GlobalTokensStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_inference_tokens_stats(
     key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
@@ -119,7 +119,7 @@ async def get_inference_tokens_stats(
         raise
 
 
-@router.get("/global/{key_type}/credits", response_model=GlobalCreditsStats)  # type: ignore
+@router.get("/global/{key_type}/credits", response_model=GlobalCreditsStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_inference_credits_stats(
     key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
@@ -132,7 +132,7 @@ async def get_inference_credits_stats(
         raise
 
 
-@router.get("/global/{key_type}/users", response_model=GlobalUsersStats)  # type: ignore
+@router.get("/global/{key_type}/users", response_model=GlobalUsersStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_inference_users_stats(
     key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
@@ -145,7 +145,7 @@ async def get_inference_users_stats(
         raise
 
 
-@router.get("/global/users", response_model=GlobalUsersStats)  # type: ignore
+@router.get("/global/users", response_model=GlobalUsersStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_aggregate_users_stats(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -157,7 +157,7 @@ async def get_aggregate_users_stats(
         raise
 
 
-@router.get("/global/summary", response_model=GlobalSummaryStats)  # type: ignore
+@router.get("/global/summary", response_model=GlobalSummaryStats, dependencies=[Depends(require_staff)])  # type: ignore
 async def get_global_summary(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -169,7 +169,9 @@ async def get_global_summary(
         raise
 
 
-@router.get("/global/messages-by-segment", response_model=GlobalSegmentMessagesStats)  # type: ignore
+@router.get(
+    "/global/messages-by-segment", response_model=GlobalSegmentMessagesStats, dependencies=[Depends(require_staff)]
+)  # type: ignore
 async def get_messages_by_segment(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -181,7 +183,11 @@ async def get_messages_by_segment(
         raise
 
 
-@router.get("/global/credits-consumption", response_model=GlobalCreditsConsumptionStats)  # type: ignore
+@router.get(
+    "/global/credits-consumption",
+    response_model=GlobalCreditsConsumptionStats,
+    dependencies=[Depends(require_staff)],
+)  # type: ignore
 async def get_credits_consumption(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -193,7 +199,9 @@ async def get_credits_consumption(
         raise
 
 
-@router.get("/global/subscriptions", response_model=GlobalSubscriptionsStats)  # type: ignore
+@router.get(
+    "/global/subscriptions", response_model=GlobalSubscriptionsStats, dependencies=[Depends(require_staff)]
+)  # type: ignore
 async def get_subscriptions_stats() -> GlobalSubscriptionsStats:
     try:
         return await StatsService.get_global_subscriptions_stats()
@@ -202,7 +210,11 @@ async def get_subscriptions_stats() -> GlobalSubscriptionsStats:
         raise
 
 
-@router.get("/global/subscribers-over-time", response_model=GlobalSubscribersOverTimeStats)  # type: ignore
+@router.get(
+    "/global/subscribers-over-time",
+    response_model=GlobalSubscribersOverTimeStats,
+    dependencies=[Depends(require_staff)],
+)  # type: ignore
 async def get_subscribers_over_time(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -13,6 +13,7 @@ from src.interfaces.stats import (
     GlobalChatTokensStats,
     GlobalSummaryStats,
     GlobalUsersStats,
+    UsersWindow,
     GlobalSegmentMessagesStats,
     GlobalCreditsConsumptionStats,
     GlobalSubscriptionsStats,
@@ -82,9 +83,10 @@ async def get_chat_tokens_stats(
 async def get_chat_users_stats(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
+    window: UsersWindow = Query(UsersWindow.day, description="Rolling window: day (DAU), week (WAU), month (MAU)"),
 ) -> GlobalUsersStats:
     try:
-        return await StatsService.get_global_chat_users_stats(start_date, end_date)
+        return await StatsService.get_global_chat_users_stats(start_date, end_date, window)
     except Exception as e:
         logger.error(f"Error in chat users stats route: {str(e)}", exc_info=True)
         raise
@@ -137,9 +139,10 @@ async def get_inference_users_stats(
     key_type: InferenceKeyType,
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
+    window: UsersWindow = Query(UsersWindow.day, description="Rolling window: day (DAU), week (WAU), month (MAU)"),
 ) -> GlobalUsersStats:
     try:
-        return await StatsService._get_inference_users_stats(ApiKeyType(key_type.value), start_date, end_date)
+        return await StatsService._get_inference_users_stats(ApiKeyType(key_type.value), start_date, end_date, window)
     except Exception as e:
         logger.error(f"Error in {key_type.value} users stats route: {str(e)}", exc_info=True)
         raise
@@ -149,9 +152,10 @@ async def get_inference_users_stats(
 async def get_aggregate_users_stats(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
+    window: UsersWindow = Query(UsersWindow.day, description="Rolling window: day (DAU), week (WAU), month (MAU)"),
 ) -> GlobalUsersStats:
     try:
-        return await StatsService.get_global_users_stats(start_date, end_date)
+        return await StatsService.get_global_users_stats(start_date, end_date, window)
     except Exception as e:
         logger.error(f"Error in aggregate users stats route: {str(e)}", exc_info=True)
         raise

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -19,6 +19,7 @@ from src.interfaces.stats import (
     GlobalSubscriptionsStats,
     GlobalSubscribersOverTimeStats,
     GlobalLatestSubscribersStats,
+    GlobalSubscriptionsRevenueStats,
 )
 from src.models.user import User
 from src.routes.stats import router
@@ -105,6 +106,22 @@ async def get_latest_subscribers(
         return await StatsService.get_latest_subscribers(limit)
     except Exception as e:
         logger.error(f"Error in latest subscribers route: {str(e)}", exc_info=True)
+        raise
+
+
+@router.get(
+    "/global/subscriptions/revenue",
+    response_model=GlobalSubscriptionsRevenueStats,
+    dependencies=[Depends(require_staff)],
+)  # type: ignore
+async def get_subscriptions_revenue(
+    start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
+    end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
+) -> GlobalSubscriptionsRevenueStats:
+    try:
+        return await StatsService.get_global_subscriptions_revenue(start_date, end_date)
+    except Exception as e:
+        logger.error(f"Error in subscriptions revenue route: {str(e)}", exc_info=True)
         raise
 
 

--- a/src/routes/stats/stats.py
+++ b/src/routes/stats/stats.py
@@ -95,11 +95,11 @@ async def get_chat_users_stats(
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/subscriptions/latest",
     response_model=GlobalLatestSubscribersStats,
     dependencies=[Depends(require_staff)],
-)  # type: ignore
+)
 async def get_latest_subscribers(
     limit: int = Query(20, ge=1, le=200, description="Number of most recent subscriptions to return"),
 ) -> GlobalLatestSubscribersStats:
@@ -110,11 +110,11 @@ async def get_latest_subscribers(
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/subscriptions/revenue",
     response_model=GlobalSubscriptionsRevenueStats,
     dependencies=[Depends(require_staff)],
-)  # type: ignore
+)
 async def get_subscriptions_revenue(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -126,11 +126,11 @@ async def get_subscriptions_revenue(
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/subscriptions/churn",
     response_model=GlobalSubscriptionsChurnStats,
     dependencies=[Depends(require_staff)],
-)  # type: ignore
+)
 async def get_subscriptions_churn(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -223,9 +223,9 @@ async def get_global_summary(
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/messages-by-segment", response_model=GlobalSegmentMessagesStats, dependencies=[Depends(require_staff)]
-)  # type: ignore
+)
 async def get_messages_by_segment(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -237,11 +237,11 @@ async def get_messages_by_segment(
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/credits-consumption",
     response_model=GlobalCreditsConsumptionStats,
     dependencies=[Depends(require_staff)],
-)  # type: ignore
+)
 async def get_credits_consumption(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),
@@ -253,9 +253,9 @@ async def get_credits_consumption(
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/subscriptions", response_model=GlobalSubscriptionsStats, dependencies=[Depends(require_staff)]
-)  # type: ignore
+)
 async def get_subscriptions_stats() -> GlobalSubscriptionsStats:
     try:
         return await StatsService.get_global_subscriptions_stats()
@@ -264,11 +264,11 @@ async def get_subscriptions_stats() -> GlobalSubscriptionsStats:
         raise
 
 
-@router.get(
+@router.get(  # type: ignore
     "/global/subscribers-over-time",
     response_model=GlobalSubscribersOverTimeStats,
     dependencies=[Depends(require_staff)],
-)  # type: ignore
+)
 async def get_subscribers_over_time(
     start_date: date = Query(..., description="Start date in format YYYY-MM-DD"),
     end_date: date = Query(..., description="End date in format YYYY-MM-DD"),

--- a/src/services/auth.py
+++ b/src/services/auth.py
@@ -141,6 +141,13 @@ async def get_current_user(
     return await _resolve_user_from_token(token)
 
 
+async def require_staff(user: User = Depends(get_current_user)) -> User:
+    """Allow only LibertAI staff (backoffice endpoints)."""
+    if not user.is_libertai_staff:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Staff access required")
+    return user
+
+
 async def get_optional_user(
     authorization: str | None = Header(default=None),
     libertai_auth: str | None = Cookie(default=None),

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -36,6 +36,9 @@ from src.interfaces.stats import (
     TierSubscribersDay,
     LatestSubscriber,
     GlobalLatestSubscribersStats,
+    MrrByTier,
+    MrrDay,
+    GlobalSubscriptionsRevenueStats,
 )
 from src.models.anon_chat_usage import AnonChatUsage
 from src.models.api_key import ApiKey
@@ -43,7 +46,9 @@ from src.models.base import AsyncSessionLocal
 from src.models.chat_request import ChatRequest
 from src.models.inference_call import InferenceCall
 from src.models.plan_subscription import PlanSubscription
+from src.models.plan_subscription_event import PlanSubscriptionEvent
 from src.models.user import User
+from src.subscription_tiers import get_tier
 from src.utils.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -931,4 +936,127 @@ class StatsService:
                 return GlobalLatestSubscribersStats(subscribers=subscribers)
         except Exception as e:
             logger.error(f"Error retrieving latest subscribers: {str(e)}", exc_info=True)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    # Events that end a subscription's paying life. ``cancelled_for_upgrade`` ends the old row of
+    # an upgrade pair (the replacement row has its own ``activated``), avoiding double-counting.
+    _TERMINAL_EVENTS = ("cancelled", "expired", "finished", "cancelled_for_upgrade")
+
+    @staticmethod
+    def _replay_subscription_timelines(subs, events_by_sub) -> list[dict]:
+        """Rebuild each sub's activation window and tier timeline from its event log.
+
+        - activated_on: day of the FIRST ``activated`` event (renewals repeat it), None if never.
+        - ended_on: day of the first terminal event (exclusive — no MRR that day), None if live.
+        - tier_changes: [(activation_day, initial_tier)] + one entry per ``downgraded`` event.
+          Initial tier from the ``created`` event metadata, falling back to the row's current tier
+          (covers rows predating event logging).
+        """
+        timelines: list[dict] = []
+        for sub in subs:
+            events = sorted(events_by_sub.get(sub.id, []), key=lambda e: e.created_at)
+            activated_on: date | None = None
+            ended_on: date | None = None
+            initial_tier: str | None = None
+            downgrades: list[tuple[date, str]] = []
+            for e in events:
+                day = e.created_at.date()
+                if e.event_type == "created" and e.metadata_json and e.metadata_json.get("tier"):
+                    initial_tier = e.metadata_json["tier"]
+                elif e.event_type == "activated" and activated_on is None:
+                    activated_on = day
+                elif e.event_type == "downgraded" and e.metadata_json and e.metadata_json.get("to"):
+                    downgrades.append((day, e.metadata_json["to"]))
+                elif e.event_type in StatsService._TERMINAL_EVENTS and ended_on is None:
+                    ended_on = day
+            tier_changes: list[tuple[date, str]] = []
+            if activated_on is not None:
+                tier_changes = [(activated_on, initial_tier or sub.tier)] + downgrades
+            timelines.append(
+                {
+                    "user_id": sub.user_id,
+                    "activated_on": activated_on,
+                    "ended_on": ended_on,
+                    "tier_changes": tier_changes,
+                }
+            )
+        return timelines
+
+    @staticmethod
+    def _tier_at(timeline: dict, day: date) -> str | None:
+        """The sub's tier on ``day``, or None if not active that day."""
+        if timeline["activated_on"] is None or day < timeline["activated_on"]:
+            return None
+        if timeline["ended_on"] is not None and day >= timeline["ended_on"]:
+            return None
+        tier = None
+        for change_day, change_tier in timeline["tier_changes"]:
+            if change_day <= day:
+                tier = change_tier
+        return tier
+
+    @staticmethod
+    def _mrr_daily(timelines: list[dict], start_date: date, end_date: date) -> list[MrrDay]:
+        daily: list[MrrDay] = []
+        day = start_date
+        while day <= end_date:
+            total = 0.0
+            for t in timelines:
+                tier = StatsService._tier_at(t, day)
+                if tier:
+                    total += get_tier(tier).price_cents / 100
+            daily.append(MrrDay(date=day.strftime("%Y-%m-%d"), mrr=round(total, 2)))
+            day += timedelta(days=1)
+        return daily
+
+    @staticmethod
+    async def get_global_subscriptions_revenue(start_date: date, end_date: date) -> GlobalSubscriptionsRevenueStats:
+        """Revolut MRR (nominal, currency-blind, trials excluded), event-replayed over the range."""
+        try:
+            async with AsyncSessionLocal() as db:
+                subs = (
+                    (
+                        await db.execute(
+                            select(PlanSubscription).where(
+                                PlanSubscription.provider == "revolut",
+                                PlanSubscription.is_trial.is_(False),
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                sub_ids = [s.id for s in subs]
+                events = (
+                    (
+                        await db.execute(
+                            select(PlanSubscriptionEvent).where(
+                                PlanSubscriptionEvent.subscription_id.in_(sub_ids)
+                            )
+                        )
+                    ).scalars().all()
+                    if sub_ids
+                    else []
+                )
+                events_by_sub: dict = {}
+                for e in events:
+                    events_by_sub.setdefault(e.subscription_id, []).append(e)
+
+                timelines = StatsService._replay_subscription_timelines(subs, events_by_sub)
+                daily = StatsService._mrr_daily(timelines, start_date, end_date)
+
+                today = date.today()
+                by_tier: dict[str, float] = {}
+                for t in timelines:
+                    tier = StatsService._tier_at(t, today)
+                    if tier:
+                        by_tier[tier] = by_tier.get(tier, 0.0) + get_tier(tier).price_cents / 100
+                current_mrr = round(sum(by_tier.values()), 2)
+                return GlobalSubscriptionsRevenueStats(
+                    current_mrr=current_mrr,
+                    mrr_by_tier=[MrrByTier(tier=k, mrr=round(v, 2)) for k, v in sorted(by_tier.items())],
+                    daily=daily,
+                )
+        except Exception as e:
+            logger.error(f"Error retrieving subscriptions revenue: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -34,6 +34,8 @@ from src.interfaces.stats import (
     TierSubscribers,
     GlobalSubscribersOverTimeStats,
     TierSubscribersDay,
+    LatestSubscriber,
+    GlobalLatestSubscribersStats,
 )
 from src.models.anon_chat_usage import AnonChatUsage
 from src.models.api_key import ApiKey
@@ -893,4 +895,40 @@ class StatsService:
                 return GlobalSubscribersOverTimeStats(daily=daily)
         except Exception as e:
             logger.error(f"Error retrieving subscribers-over-time stats: {str(e)}", exc_info=True)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @staticmethod
+    async def get_latest_subscribers(limit: int = 20) -> GlobalLatestSubscribersStats:
+        """Most recent plan subscriptions (all providers), newest first, with a display label per user."""
+        try:
+            async with AsyncSessionLocal() as db:
+                rows = (
+                    await db.execute(
+                        select(PlanSubscription, User)
+                        .join(User, PlanSubscription.user_id == User.id)
+                        .order_by(PlanSubscription.created_at.desc())
+                        .limit(limit)
+                    )
+                ).all()
+
+                subscribers = []
+                for sub, user in rows:
+                    label = user.email or user.display_name or user.address or str(user.id)
+                    subscribers.append(
+                        LatestSubscriber(
+                            user_label=label,
+                            tier=sub.tier,
+                            status=sub.status,
+                            provider=sub.provider,
+                            is_trial=sub.is_trial,
+                            cancel_at_period_end=sub.cancel_at_period_end,
+                            created_at=sub.created_at.isoformat(),
+                            current_period_end=sub.current_period_end.isoformat()
+                            if sub.current_period_end
+                            else None,
+                        )
+                    )
+                return GlobalLatestSubscribersStats(subscribers=subscribers)
+        except Exception as e:
+            logger.error(f"Error retrieving latest subscribers: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -39,6 +39,8 @@ from src.interfaces.stats import (
     MrrByTier,
     MrrDay,
     GlobalSubscriptionsRevenueStats,
+    ChurnWeek,
+    GlobalSubscriptionsChurnStats,
 )
 from src.models.anon_chat_usage import AnonChatUsage
 from src.models.api_key import ApiKey
@@ -957,6 +959,7 @@ class StatsService:
             events = sorted(events_by_sub.get(sub.id, []), key=lambda e: e.created_at)
             activated_on: date | None = None
             ended_on: date | None = None
+            terminal_event: str | None = None
             initial_tier: str | None = None
             downgrades: list[tuple[date, str]] = []
             for e in events:
@@ -969,6 +972,7 @@ class StatsService:
                     downgrades.append((day, e.metadata_json["to"]))
                 elif e.event_type in StatsService._TERMINAL_EVENTS and ended_on is None:
                     ended_on = day
+                    terminal_event = e.event_type
             tier_changes: list[tuple[date, str]] = []
             if activated_on is not None:
                 tier_changes = [(activated_on, initial_tier or sub.tier)] + downgrades
@@ -977,6 +981,7 @@ class StatsService:
                     "user_id": sub.user_id,
                     "activated_on": activated_on,
                     "ended_on": ended_on,
+                    "terminal_event": terminal_event,
                     "tier_changes": tier_changes,
                 }
             )
@@ -1059,4 +1064,89 @@ class StatsService:
                 )
         except Exception as e:
             logger.error(f"Error retrieving subscriptions revenue: {str(e)}", exc_info=True)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @staticmethod
+    def _churn_from_timelines(
+        timelines: list[dict], start_date: date, end_date: date
+    ) -> GlobalSubscriptionsChurnStats:
+        """Weekly new vs churned subs. Weeks start Monday and are clipped to the requested range.
+
+        An activation is not "new" if the same user had another sub terminated with
+        ``cancelled_for_upgrade`` in the same ISO week (upgrade replacement).
+        """
+
+        def week_of(day: date) -> date:
+            return day - timedelta(days=day.weekday())
+
+        upgrade_weeks: dict = {}
+        for t in timelines:
+            if t["terminal_event"] == "cancelled_for_upgrade" and t["ended_on"]:
+                upgrade_weeks.setdefault(t["user_id"], set()).add(week_of(t["ended_on"]))
+
+        weeks: dict[date, dict[str, int]] = {}
+        w = week_of(start_date)
+        while w <= end_date:
+            weeks[w] = {"new": 0, "churned": 0}
+            w += timedelta(days=7)
+
+        total_new = 0
+        total_churned = 0
+        for t in timelines:
+            a = t["activated_on"]
+            if a and start_date <= a <= end_date:
+                if week_of(a) not in upgrade_weeks.get(t["user_id"], set()):
+                    weeks[week_of(a)]["new"] += 1
+                    total_new += 1
+            e = t["ended_on"]
+            if (
+                e
+                and start_date <= e <= end_date
+                and t["terminal_event"] in ("cancelled", "expired", "finished")
+            ):
+                weeks[week_of(e)]["churned"] += 1
+                total_churned += 1
+
+        weekly = [
+            ChurnWeek(week_start=w.strftime("%Y-%m-%d"), new=c["new"], churned=c["churned"], net=c["new"] - c["churned"])
+            for w, c in sorted(weeks.items())
+        ]
+        return GlobalSubscriptionsChurnStats(weekly=weekly, total_new=total_new, total_churned=total_churned)
+
+    @staticmethod
+    async def get_global_subscriptions_churn(start_date: date, end_date: date) -> GlobalSubscriptionsChurnStats:
+        """Revolut new-vs-churned subscribers per week (event-based; trials excluded)."""
+        try:
+            async with AsyncSessionLocal() as db:
+                subs = (
+                    (
+                        await db.execute(
+                            select(PlanSubscription).where(
+                                PlanSubscription.provider == "revolut",
+                                PlanSubscription.is_trial.is_(False),
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                sub_ids = [s.id for s in subs]
+                events = (
+                    (
+                        await db.execute(
+                            select(PlanSubscriptionEvent).where(
+                                PlanSubscriptionEvent.subscription_id.in_(sub_ids)
+                            )
+                        )
+                    ).scalars().all()
+                    if sub_ids
+                    else []
+                )
+                events_by_sub: dict = {}
+                for e in events:
+                    events_by_sub.setdefault(e.subscription_id, []).append(e)
+                timelines = StatsService._replay_subscription_timelines(subs, events_by_sub)
+                return StatsService._churn_from_timelines(timelines, start_date, end_date)
+        except Exception as e:
+            logger.error(f"Error retrieving subscriptions churn: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -56,6 +56,15 @@ from src.utils.logger import setup_logger
 logger = setup_logger(__name__)
 
 
+def _tier_price(tier: str) -> float:
+    """Price for a tier; unknown/legacy tier strings are skipped (0) instead of 500ing the endpoint."""
+    try:
+        return get_tier(tier).price_cents / 100
+    except ValueError:
+        logger.warning(f"Unknown subscription tier in MRR computation: {tier}")
+        return 0.0
+
+
 class StatsService:
     @staticmethod
     async def get_dashboard_stats(user_address: str) -> DashboardStats:
@@ -943,6 +952,8 @@ class StatsService:
     # Events that end a subscription's paying life. ``cancelled_for_upgrade`` ends the old row of
     # an upgrade pair (the replacement row has its own ``activated``), avoiding double-counting.
     _TERMINAL_EVENTS = ("cancelled", "expired", "finished", "cancelled_for_upgrade")
+    # Terminal events that count as churn (excludes cancelled_for_upgrade, an upgrade replacement).
+    _CHURN_TERMINAL_EVENTS = tuple(e for e in _TERMINAL_EVENTS if e != "cancelled_for_upgrade")
 
     @staticmethod
     def _replay_subscription_timelines(subs, events_by_sub) -> list[dict]:
@@ -1009,7 +1020,7 @@ class StatsService:
             for t in timelines:
                 tier = StatsService._tier_at(t, day)
                 if tier:
-                    total += get_tier(tier).price_cents / 100
+                    total += _tier_price(tier)
             daily.append(MrrDay(date=day.strftime("%Y-%m-%d"), mrr=round(total, 2)))
             day += timedelta(days=1)
         return daily
@@ -1055,7 +1066,7 @@ class StatsService:
                 for t in timelines:
                     tier = StatsService._tier_at(t, today)
                     if tier:
-                        by_tier[tier] = by_tier.get(tier, 0.0) + get_tier(tier).price_cents / 100
+                        by_tier[tier] = by_tier.get(tier, 0.0) + _tier_price(tier)
                 current_mrr = round(sum(by_tier.values()), 2)
                 return GlobalSubscriptionsRevenueStats(
                     current_mrr=current_mrr,
@@ -1102,7 +1113,7 @@ class StatsService:
             if (
                 e
                 and start_date <= e <= end_date
-                and t["terminal_event"] in ("cancelled", "expired", "finished")
+                and t["terminal_event"] in StatsService._CHURN_TERMINAL_EVENTS
             ):
                 weeks[week_of(e)]["churned"] += 1
                 total_churned += 1

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -1,5 +1,5 @@
 from calendar import month_abbr
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta, date, timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, cast, Date, Integer, select, distinct, case, literal, and_
@@ -981,6 +981,11 @@ class StatsService:
                     activated_on = day
                 elif e.event_type == "downgraded" and e.metadata_json and e.metadata_json.get("to"):
                     downgrades.append((day, e.metadata_json["to"]))
+                elif e.event_type == "downgraded":
+                    logger.warning(
+                        f"downgraded event {e.id} (subscription {sub.id}) missing tier metadata; "
+                        "MRR keeps prior tier"
+                    )
                 elif e.event_type in StatsService._TERMINAL_EVENTS and ended_on is None:
                     ended_on = day
                     terminal_event = e.event_type
@@ -1061,7 +1066,7 @@ class StatsService:
                 timelines = StatsService._replay_subscription_timelines(subs, events_by_sub)
                 daily = StatsService._mrr_daily(timelines, start_date, end_date)
 
-                today = date.today()
+                today = datetime.now(timezone.utc).date()
                 by_tier: dict[str, float] = {}
                 for t in timelines:
                     tier = StatsService._tier_at(t, today)
@@ -1084,7 +1089,10 @@ class StatsService:
         """Weekly new vs churned subs. Weeks start Monday and are clipped to the requested range.
 
         An activation is not "new" if the same user had another sub terminated with
-        ``cancelled_for_upgrade`` in the same ISO week (upgrade replacement).
+        ``cancelled_for_upgrade`` in the same ISO week (upgrade replacement). This match is by
+        ISO week, so an upgrade pair straddling a week boundary (old sub ends Sunday, new
+        activates Monday) counts as +1 new / 0 churned instead of being netted out — inherent
+        to week bucketing, rare.
         """
 
         def week_of(day: date) -> date:

--- a/src/services/stats.py
+++ b/src/services/stats.py
@@ -25,6 +25,7 @@ from src.interfaces.stats import (
     GlobalSummaryStats,
     DailyActiveUsers,
     GlobalUsersStats,
+    UsersWindow,
     GlobalSegmentMessagesStats,
     SegmentMessageUsage,
     GlobalCreditsConsumptionStats,
@@ -393,7 +394,43 @@ class StatsService:
             )
 
     @staticmethod
-    async def _get_inference_users_stats(key_type: ApiKeyType, start_date: date, end_date: date) -> GlobalUsersStats:
+    def _rolling_users_stats(
+        rows: list[tuple[date, str]], start_date: date, end_date: date, window_days: int
+    ) -> GlobalUsersStats:
+        """Rolling distinct-user counts from (day, identity) activity rows.
+
+        For each day in [start_date, end_date], counts identities active in the trailing
+        ``window_days`` days (inclusive). ``rows`` may (and for window > 1 must) include
+        activity from before start_date. Days with a 0 count are omitted (sparse, matching
+        the plain-DAU output). total_unique_users only counts activity inside the range.
+        """
+        by_day: dict[date, set[str]] = {}
+        for day, ident in rows:
+            by_day.setdefault(day, set()).add(ident)
+
+        overall_in_range: set[str] = set()
+        for day, idents in by_day.items():
+            if start_date <= day <= end_date:
+                overall_in_range |= idents
+
+        daily: list[DailyActiveUsers] = []
+        current = start_date
+        while current <= end_date:
+            window_start = current - timedelta(days=window_days - 1)
+            active: set[str] = set()
+            for day, idents in by_day.items():
+                if window_start <= day <= current:
+                    active |= idents
+            if active:
+                daily.append(DailyActiveUsers(date=current.strftime("%Y-%m-%d"), active_users=len(active)))
+            current += timedelta(days=1)
+
+        return GlobalUsersStats(total_unique_users=len(overall_in_range), daily_active_users=daily)
+
+    @staticmethod
+    async def _get_inference_users_stats(
+        key_type: ApiKeyType, start_date: date, end_date: date, window: UsersWindow = UsersWindow.day
+    ) -> GlobalUsersStats:
         """Daily active users + range-wide unique users for an inference key type.
 
         Identity is the owning user: ``api_keys.user_id`` for api/cli, ``api_keys.liberclaw_user_id``
@@ -404,98 +441,68 @@ class StatsService:
             return GlobalUsersStats(total_unique_users=0, daily_active_users=[])
 
         async with AsyncSessionLocal() as db:
-            start_datetime = datetime.combine(start_date, datetime.min.time())
+            fetch_start = start_date - timedelta(days=window.days - 1)
+            start_datetime = datetime.combine(fetch_start, datetime.min.time())
             end_datetime = datetime.combine(end_date, datetime.max.time())
 
             identity = ApiKey.liberclaw_user_id if key_type == ApiKeyType.liberclaw else ApiKey.user_id
-            base_filter = (
-                ApiKey.type == key_type,
-                identity.isnot(None),
-                InferenceCall.used_at >= start_datetime,
-                InferenceCall.used_at <= end_datetime,
-            )
-
-            daily_rows = (
+            raw = (
                 await db.execute(
                     select(
                         cast(InferenceCall.used_at, Date).label("date"),
-                        func.count(distinct(identity)).label("active_users"),
+                        identity.label("ident"),
                     )
                     .select_from(InferenceCall)
                     .join(ApiKey, InferenceCall.api_key_id == ApiKey.id)
-                    .where(*base_filter)
-                    .group_by(cast(InferenceCall.used_at, Date))
-                    .order_by(cast(InferenceCall.used_at, Date))
+                    .where(
+                        ApiKey.type == key_type,
+                        identity.isnot(None),
+                        InferenceCall.used_at >= start_datetime,
+                        InferenceCall.used_at <= end_datetime,
+                    )
+                    .distinct()
                 )
             ).all()
-
-            total = (
-                await db.execute(
-                    select(func.count(distinct(identity)))
-                    .select_from(InferenceCall)
-                    .join(ApiKey, InferenceCall.api_key_id == ApiKey.id)
-                    .where(*base_filter)
-                )
-            ).scalar() or 0
-
-            return GlobalUsersStats(
-                total_unique_users=int(total),
-                daily_active_users=[
-                    DailyActiveUsers(date=r.date.strftime("%Y-%m-%d"), active_users=int(r.active_users or 0))
-                    for r in daily_rows
-                ],
-            )
+            rows = [(r.date, str(r.ident)) for r in raw]
+            return StatsService._rolling_users_stats(rows, start_date, end_date, window.days)
 
     @staticmethod
-    async def get_global_chat_users_stats(start_date: date, end_date: date) -> GlobalUsersStats:
+    async def get_global_chat_users_stats(
+        start_date: date, end_date: date, window: UsersWindow = UsersWindow.day
+    ) -> GlobalUsersStats:
         """Daily active users + range-wide unique users for chat (separate chat_requests table)."""
         try:
             async with AsyncSessionLocal() as db:
-                start_datetime = datetime.combine(start_date, datetime.min.time())
+                fetch_start = start_date - timedelta(days=window.days - 1)
+                start_datetime = datetime.combine(fetch_start, datetime.min.time())
                 end_datetime = datetime.combine(end_date, datetime.max.time())
 
-                base_filter = (
-                    ApiKey.user_id.isnot(None),
-                    ChatRequest.created_at >= start_datetime,
-                    ChatRequest.created_at <= end_datetime,
-                )
-
-                daily_rows = (
+                raw = (
                     await db.execute(
                         select(
                             cast(ChatRequest.created_at, Date).label("date"),
-                            func.count(distinct(ApiKey.user_id)).label("active_users"),
+                            ApiKey.user_id.label("ident"),
                         )
                         .select_from(ChatRequest)
                         .join(ApiKey, ChatRequest.api_key_id == ApiKey.id)
-                        .where(*base_filter)
-                        .group_by(cast(ChatRequest.created_at, Date))
-                        .order_by(cast(ChatRequest.created_at, Date))
+                        .where(
+                            ApiKey.user_id.isnot(None),
+                            ChatRequest.created_at >= start_datetime,
+                            ChatRequest.created_at <= end_datetime,
+                        )
+                        .distinct()
                     )
                 ).all()
-
-                total = (
-                    await db.execute(
-                        select(func.count(distinct(ApiKey.user_id)))
-                        .select_from(ChatRequest)
-                        .join(ApiKey, ChatRequest.api_key_id == ApiKey.id)
-                        .where(*base_filter)
-                    )
-                ).scalar() or 0
-
-                return GlobalUsersStats(
-                    total_unique_users=int(total),
-                    daily_active_users=[
-                        DailyActiveUsers(date=r.date.strftime("%Y-%m-%d"), active_users=int(r.active_users or 0))
-                        for r in daily_rows
-                    ],
-                )
+                rows = [(r.date, str(r.ident)) for r in raw]
+                return StatsService._rolling_users_stats(rows, start_date, end_date, window.days)
         except Exception as e:
             logger.error(f"Error retrieving chat users stats: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")
 
     @staticmethod
-    async def get_global_users_stats(start_date: date, end_date: date) -> GlobalUsersStats:
+    async def get_global_users_stats(
+        start_date: date, end_date: date, window: UsersWindow = UsersWindow.day
+    ) -> GlobalUsersStats:
         """Aggregate distinct users across api / cli / chat / liberclaw, deduplicated.
 
         api/cli/chat share ``users.id`` (namespaced ``u:``); liberclaw lives in its own
@@ -506,7 +513,8 @@ class StatsService:
         """
         try:
             async with AsyncSessionLocal() as db:
-                start_datetime = datetime.combine(start_date, datetime.min.time())
+                fetch_start = start_date - timedelta(days=window.days - 1)
+                start_datetime = datetime.combine(fetch_start, datetime.min.time())
                 end_datetime = datetime.combine(end_date, datetime.max.time())
 
                 inference_rows = (
@@ -545,31 +553,17 @@ class StatsService:
                     )
                 ).all()
 
-                per_day: dict[str, set[str]] = {}
-                overall: set[str] = set()
-
-                def _add(day: str, ident: str | None) -> None:
-                    if ident is None:
-                        return
-                    per_day.setdefault(day, set()).add(ident)
-                    overall.add(ident)
-
+                rows: list[tuple[date, str]] = []
                 for r in inference_rows:
-                    day = r.date.strftime("%Y-%m-%d")
                     if r.type == ApiKeyType.liberclaw:
-                        _add(day, f"l:{r.liberclaw_user_id}" if r.liberclaw_user_id else None)
-                    else:
-                        _add(day, f"u:{r.user_id}" if r.user_id else None)
-
+                        if r.liberclaw_user_id:
+                            rows.append((r.date, f"l:{r.liberclaw_user_id}"))
+                    elif r.user_id:
+                        rows.append((r.date, f"u:{r.user_id}"))
                 for cr in chat_rows:
-                    _add(cr.date.strftime("%Y-%m-%d"), f"u:{cr.user_id}" if cr.user_id else None)
-
-                return GlobalUsersStats(
-                    total_unique_users=len(overall),
-                    daily_active_users=[
-                        DailyActiveUsers(date=day, active_users=len(idents)) for day, idents in sorted(per_day.items())
-                    ],
-                )
+                    if cr.user_id:
+                        rows.append((cr.date, f"u:{cr.user_id}"))
+                return StatsService._rolling_users_stats(rows, start_date, end_date, window.days)
         except Exception as e:
             logger.error(f"Error retrieving aggregate users stats: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")

--- a/tests/test_auth_me_staff.py
+++ b/tests/test_auth_me_staff.py
@@ -1,0 +1,16 @@
+from src.interfaces.auth import CurrentUserResponse
+from src.models.base import AsyncSessionLocal
+from src.models.user import User
+
+
+async def test_user_defaults_to_non_staff():
+    async with AsyncSessionLocal() as db:
+        user = User(email="staff-default@example.com")
+        db.add(user)
+        await db.commit()
+        assert user.is_libertai_staff is False
+
+
+async def test_current_user_response_exposes_staff_flag():
+    resp = CurrentUserResponse(id="x", is_libertai_staff=True)
+    assert resp.is_libertai_staff is True

--- a/tests/test_require_staff.py
+++ b/tests/test_require_staff.py
@@ -1,0 +1,36 @@
+import pytest
+from fastapi import HTTPException
+
+from src.models.base import AsyncSessionLocal
+from src.models.user import User
+from src.services.auth import get_current_user, require_staff
+from src.services.auth_tokens import create_access_token
+
+
+async def _make_user(email: str, staff: bool) -> User:
+    async with AsyncSessionLocal() as db:
+        user = User(email=email)
+        user.is_libertai_staff = staff
+        db.add(user)
+        await db.commit()
+        return user
+
+
+async def test_staff_user_passes():
+    user = await _make_user("staff@example.com", staff=True)
+    resolved = await get_current_user(authorization=f"Bearer {create_access_token(user.id)}")
+    assert (await require_staff(resolved)).id == user.id
+
+
+async def test_non_staff_user_gets_403():
+    user = await _make_user("pleb@example.com", staff=False)
+    resolved = await get_current_user(authorization=f"Bearer {create_access_token(user.id)}")
+    with pytest.raises(HTTPException) as exc:
+        await require_staff(resolved)
+    assert exc.value.status_code == 403
+
+
+async def test_missing_token_still_401():
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(authorization=None, libertai_auth=None)
+    assert exc.value.status_code == 401

--- a/tests/test_staff_gating.py
+++ b/tests/test_staff_gating.py
@@ -1,51 +1,83 @@
-import pytest
-from httpx import ASGITransport, AsyncClient
+import uuid
 
-from src.main import app
+import pytest
+
 from src.models.base import AsyncSessionLocal
 from src.models.user import User
 from src.services.auth_tokens import create_access_token
 
 pytestmark = pytest.mark.asyncio
 
+# A valid lowercase Base/EVM address (lowercase => no checksum requirement).
+ADDR = "0x000000000000000000000000000000000000dead"
+
 
 async def _token(staff: bool) -> str:
     async with AsyncSessionLocal() as db:
-        user = User(email=f"gate-{'staff' if staff else 'user'}@example.com")
+        user = User(email=f"gate-{'staff' if staff else 'user'}-{uuid.uuid4().hex}@example.com")
         user.is_libertai_staff = staff
         db.add(user)
         await db.commit()
         return create_access_token(user.id)
 
 
-@pytest.fixture
-def client():
-    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
-
-
-async def test_global_stats_requires_auth(client):
-    r = await client.get("/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02")
+async def test_global_stats_requires_auth(async_client):
+    r = await async_client.get("/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02")
     assert r.status_code == 401
 
 
-async def test_global_stats_rejects_non_staff(client):
+async def test_global_stats_rejects_non_staff(async_client):
     token = await _token(staff=False)
-    r = await client.get(
+    r = await async_client.get(
         "/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 403
 
 
-async def test_global_stats_allows_staff(client):
+async def test_global_stats_allows_staff(async_client):
     token = await _token(staff=True)
-    r = await client.get(
+    r = await async_client.get(
         "/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert r.status_code == 200
 
 
-async def test_voucher_post_requires_staff(client):
-    r = await client.post("/credits/vouchers", json={"amount": 5, "email": "nobody@example.com"})
+async def test_voucher_post_requires_staff(async_client):
+    r = await async_client.post("/credits/vouchers", json={"amount": 5, "email": "nobody@example.com"})
     assert r.status_code == 401
+
+
+async def test_voucher_get_requires_auth(async_client):
+    r = await async_client.get(f"/credits/vouchers?chain=base&address={ADDR}")
+    assert r.status_code == 401
+
+
+async def test_voucher_get_allows_staff(async_client):
+    token = await _token(staff=True)
+    r = await async_client.get(
+        f"/credits/vouchers?chain=base&address={ADDR}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+async def test_voucher_expiration_requires_auth(async_client):
+    r = await async_client.post(
+        "/credits/voucher/expiration", json={"voucher_id": "not-a-real-uuid", "expired_at": None}
+    )
+    assert r.status_code == 401
+
+
+async def test_voucher_expiration_allows_staff(async_client):
+    token = await _token(staff=True)
+    r = await async_client.post(
+        "/credits/voucher/expiration",
+        json={"voucher_id": "not-a-real-uuid", "expired_at": None},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # Invalid (non-UUID) voucher_id is handled gracefully by the route, not a gating concern.
+    assert r.status_code == 200
+    assert r.json() is False

--- a/tests/test_staff_gating.py
+++ b/tests/test_staff_gating.py
@@ -1,0 +1,51 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.main import app
+from src.models.base import AsyncSessionLocal
+from src.models.user import User
+from src.services.auth_tokens import create_access_token
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _token(staff: bool) -> str:
+    async with AsyncSessionLocal() as db:
+        user = User(email=f"gate-{'staff' if staff else 'user'}@example.com")
+        user.is_libertai_staff = staff
+        db.add(user)
+        await db.commit()
+        return create_access_token(user.id)
+
+
+@pytest.fixture
+def client():
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_global_stats_requires_auth(client):
+    r = await client.get("/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02")
+    assert r.status_code == 401
+
+
+async def test_global_stats_rejects_non_staff(client):
+    token = await _token(staff=False)
+    r = await client.get(
+        "/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+
+
+async def test_global_stats_allows_staff(client):
+    token = await _token(staff=True)
+    r = await client.get(
+        "/stats/global/summary?start_date=2026-01-01&end_date=2026-01-02",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+
+
+async def test_voucher_post_requires_staff(client):
+    r = await client.post("/credits/vouchers", json={"amount": 5, "email": "nobody@example.com"})
+    assert r.status_code == 401

--- a/tests/test_stats_churn.py
+++ b/tests/test_stats_churn.py
@@ -1,0 +1,36 @@
+import uuid
+from datetime import date
+
+from src.services.stats import StatsService
+
+
+def _tl(user_id, activated_on, ended_on=None, terminal_event=None):
+    return {
+        "user_id": user_id,
+        "activated_on": activated_on,
+        "ended_on": ended_on,
+        "terminal_event": terminal_event,
+        "tier_changes": [(activated_on, "go")] if activated_on else [],
+    }
+
+
+def test_churn_weekly_buckets_and_upgrade_exclusion():
+    u_new = uuid.uuid4()
+    u_churn = uuid.uuid4()
+    u_upgrade = uuid.uuid4()
+    timelines = [
+        _tl(u_new, date(2026, 1, 5)),                                            # new in week of Jan 5
+        _tl(u_churn, date(2025, 12, 1), date(2026, 1, 7), "cancelled"),          # churned week of Jan 5
+        # upgrade pair, same week: old row terminated for upgrade + new row activated
+        _tl(u_upgrade, date(2025, 12, 1), date(2026, 1, 6), "cancelled_for_upgrade"),
+        _tl(u_upgrade, date(2026, 1, 6)),
+    ]
+    stats = StatsService._churn_from_timelines(timelines, date(2026, 1, 5), date(2026, 1, 11))
+    assert len(stats.weekly) == 1
+    week = stats.weekly[0]
+    assert week.week_start == "2026-01-05"
+    assert week.new == 1        # u_upgrade's re-activation excluded, u_new counted
+    assert week.churned == 1    # cancelled_for_upgrade not churn; only u_churn
+    assert week.net == 0
+    assert stats.total_new == 1
+    assert stats.total_churned == 1

--- a/tests/test_stats_revenue.py
+++ b/tests/test_stats_revenue.py
@@ -1,0 +1,89 @@
+import uuid
+from datetime import date, datetime
+
+from src.services.stats import StatsService
+
+
+class FakeSub:
+    def __init__(self, tier: str):
+        self.id = uuid.uuid4()
+        self.user_id = uuid.uuid4()
+        self.tier = tier
+
+
+class FakeEvent:
+    def __init__(self, event_type: str, created_at: datetime, metadata: dict | None = None):
+        self.event_type = event_type
+        self.created_at = created_at
+        self.metadata_json = metadata
+
+
+def _timeline(sub, events):
+    return StatsService._replay_subscription_timelines([sub], {sub.id: events})[0]
+
+
+def test_replay_basic_lifecycle():
+    sub = FakeSub(tier="plus")
+    t = _timeline(
+        sub,
+        [
+            FakeEvent("created", datetime(2026, 1, 1), {"tier": "plus"}),
+            FakeEvent("activated", datetime(2026, 1, 2)),
+            FakeEvent("activated", datetime(2026, 2, 2)),  # renewal: window start = FIRST activated
+            FakeEvent("cancelled", datetime(2026, 3, 10)),
+        ],
+    )
+    assert t["activated_on"] == date(2026, 1, 2)
+    assert t["ended_on"] == date(2026, 3, 10)
+    assert t["tier_changes"] == [(date(2026, 1, 2), "plus")]
+
+
+def test_replay_downgrade_changes_tier_at_event_time():
+    sub = FakeSub(tier="go")  # current row tier is post-downgrade
+    t = _timeline(
+        sub,
+        [
+            FakeEvent("created", datetime(2026, 1, 1), {"tier": "plus"}),
+            FakeEvent("activated", datetime(2026, 1, 1)),
+            FakeEvent("downgraded", datetime(2026, 2, 1), {"from": "plus", "to": "go"}),
+        ],
+    )
+    assert t["ended_on"] is None
+    assert t["tier_changes"] == [(date(2026, 1, 1), "plus"), (date(2026, 2, 1), "go")]
+
+
+def test_replay_upgrade_termination_and_never_activated():
+    old = FakeSub(tier="go")
+    t_old = _timeline(
+        old,
+        [
+            FakeEvent("created", datetime(2026, 1, 1), {"tier": "go"}),
+            FakeEvent("activated", datetime(2026, 1, 1)),
+            FakeEvent("cancelled_for_upgrade", datetime(2026, 2, 1)),
+        ],
+    )
+    assert t_old["ended_on"] == date(2026, 2, 1)
+
+    abandoned = FakeSub(tier="max")
+    t_ab = _timeline(abandoned, [FakeEvent("created", datetime(2026, 1, 5), {"tier": "max"})])
+    assert t_ab["activated_on"] is None  # contributes 0 MRR
+
+
+def test_mrr_from_timelines():
+    # go = $8, plus = $20 (src/subscription_tiers.py)
+    sub = FakeSub(tier="go")
+    timelines = [
+        {
+            "user_id": sub.user_id,
+            "activated_on": date(2026, 1, 1),
+            "ended_on": date(2026, 1, 3),
+            "tier_changes": [(date(2026, 1, 1), "plus")],
+        }
+    ]
+    daily = StatsService._mrr_daily(timelines, date(2026, 1, 1), date(2026, 1, 4))
+    assert [(d.date, d.mrr) for d in daily] == [
+        ("2026-01-01", 20.0),
+        ("2026-01-02", 20.0),
+        ("2026-01-03", 0.0),   # ended_on is exclusive: terminated that day
+        ("2026-01-04", 0.0),
+    ]

--- a/tests/test_stats_revenue.py
+++ b/tests/test_stats_revenue.py
@@ -87,3 +87,45 @@ def test_mrr_from_timelines():
         ("2026-01-03", 0.0),   # ended_on is exclusive: terminated that day
         ("2026-01-04", 0.0),
     ]
+
+
+def test_mrr_upgrade_pair_no_double_count():
+    # same user: old "go" sub cancelled_for_upgrade on the upgrade day, new "max" sub activated that same day.
+    user_id = uuid.uuid4()
+    timelines = [
+        {
+            "user_id": user_id,
+            "activated_on": date(2026, 1, 1),
+            "ended_on": date(2026, 1, 10),
+            "tier_changes": [(date(2026, 1, 1), "go")],
+        },
+        {
+            "user_id": user_id,
+            "activated_on": date(2026, 1, 10),
+            "ended_on": None,
+            "tier_changes": [(date(2026, 1, 10), "max")],
+        },
+    ]
+    daily = StatsService._mrr_daily(timelines, date(2026, 1, 9), date(2026, 1, 11))
+    assert [(d.date, d.mrr) for d in daily] == [
+        ("2026-01-09", 8.0),
+        ("2026-01-10", 100.0),  # old row's ended_on is exclusive: contributes 0 on the upgrade day
+        ("2026-01-11", 100.0),
+    ]
+
+
+def test_mrr_downgrade_dollar_amounts():
+    sub = FakeSub(tier="go")
+    timelines = [
+        {
+            "user_id": sub.user_id,
+            "activated_on": date(2026, 1, 1),
+            "ended_on": None,
+            "tier_changes": [(date(2026, 1, 1), "plus"), (date(2026, 2, 1), "go")],
+        }
+    ]
+    daily = StatsService._mrr_daily(timelines, date(2026, 1, 31), date(2026, 2, 1))
+    assert [(d.date, d.mrr) for d in daily] == [
+        ("2026-01-31", 20.0),
+        ("2026-02-01", 8.0),
+    ]

--- a/tests/test_stats_subscribers_latest.py
+++ b/tests/test_stats_subscribers_latest.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from src.models.base import AsyncSessionLocal
+from src.models.plan_subscription import PlanSubscription
+from src.models.user import User
+from src.services.stats import StatsService
+
+
+async def test_latest_subscribers_newest_first_with_user_label():
+    # created_at defaults to CURRENT_TIMESTAMP, which is constant within one transaction, so both
+    # rows would otherwise tie on ordering — set explicit, distinct timestamps like other tests do
+    # (e.g. test_stats_subscriptions.py's `churned.updated_at = ts`).
+    async with AsyncSessionLocal() as db:
+        u1 = User(email="sub1@example.com")
+        u2 = User(email="sub2@example.com")
+        db.add_all([u1, u2])
+        await db.flush()
+        s1 = PlanSubscription(user_id=u1.id, tier="go", status="active", provider="revolut")
+        s1.created_at = datetime(2099, 1, 1)
+        s2 = PlanSubscription(user_id=u2.id, tier="plus", status="cancelled", provider="revolut")
+        s2.created_at = datetime(2099, 1, 2)
+        db.add_all([s1, s2])
+        await db.commit()
+
+    stats = await StatsService.get_latest_subscribers(limit=1)
+    assert len(stats.subscribers) == 1
+    latest = stats.subscribers[0]
+    assert latest.user_label == "sub2@example.com"  # inserted last -> newest created_at
+    assert latest.tier == "plus"
+    assert latest.status == "cancelled"

--- a/tests/test_stats_subscriptions.py
+++ b/tests/test_stats_subscriptions.py
@@ -18,6 +18,7 @@ from src.models.chat_request import ChatRequest
 from src.models.inference_call import InferenceCall
 from src.models.plan_subscription import PlanSubscription
 from src.models.user import User
+from src.services.auth_tokens import create_access_token
 
 pytestmark = pytest.mark.asyncio
 
@@ -30,6 +31,14 @@ async def _mk_user(db) -> uuid.UUID:
     db.add(u)
     await db.flush()
     return u.id
+
+
+async def _mk_staff_headers(db) -> tuple[dict, uuid.UUID]:
+    u = User(email=f"stats-staff-{uuid.uuid4().hex}@example.com", email_verified=True)
+    u.is_libertai_staff = True
+    db.add(u)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(u.id)}"}, u.id
 
 
 async def _mk_key(db, *, user_id, key=None, type_=ApiKeyType.chat) -> uuid.UUID:
@@ -55,6 +64,9 @@ async def test_messages_by_segment_splits_anon_free_paid(async_client, monkeypat
         db.add(PlanSubscription(user_id=paid_user, tier="plus", provider="revolut", status="active"))
         user_ids += [free_user, paid_user]
 
+        headers, staff_id = await _mk_staff_headers(db)
+        user_ids.append(staff_id)
+
         for key_id, n in ((anon_key, 3), (free_key, 2), (paid_key, 4)):
             for _ in range(n):
                 cr = ChatRequest(api_key_id=key_id, input_tokens=1, output_tokens=1, cached_tokens=0, model_name="m")
@@ -63,7 +75,9 @@ async def test_messages_by_segment_splits_anon_free_paid(async_client, monkeypat
         await db.commit()
 
     try:
-        resp = await async_client.get(f"/stats/global/messages-by-segment?start_date={_DAY}&end_date={_DAY}")
+        resp = await async_client.get(
+            f"/stats/global/messages-by-segment?start_date={_DAY}&end_date={_DAY}", headers=headers
+        )
         assert resp.status_code == 200, resp.text
         body = resp.json()
         counts = {m["segment"]: m["message_count"] for m in body["messages"]}
@@ -93,10 +107,15 @@ async def test_credits_consumption_splits_tier_and_prepaid(async_client):
             )
             ic.used_at = _TS
             db.add(ic)
+
+        headers, staff_id = await _mk_staff_headers(db)
+        user_ids.append(staff_id)
         await db.commit()
 
     try:
-        resp = await async_client.get(f"/stats/global/credits-consumption?start_date={_DAY}&end_date={_DAY}")
+        resp = await async_client.get(
+            f"/stats/global/credits-consumption?start_date={_DAY}&end_date={_DAY}", headers=headers
+        )
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["total_tier_credits"] == pytest.approx(0.8)
@@ -132,10 +151,15 @@ async def test_subscribers_over_time_dedups_resubscribe_and_skips_abandoned(asyn
         abandoned = await _mk_user(db)
         db.add(PlanSubscription(user_id=abandoned, tier="plus", provider="revolut", status="expired"))
         user_ids += [resub, abandoned]
+
+        headers, staff_id = await _mk_staff_headers(db)
+        user_ids.append(staff_id)
         await db.commit()
 
     try:
-        resp = await async_client.get(f"/stats/global/subscribers-over-time?start_date={day}&end_date={day}")
+        resp = await async_client.get(
+            f"/stats/global/subscribers-over-time?start_date={day}&end_date={day}", headers=headers
+        )
         assert resp.status_code == 200, resp.text
         plus = {d["date"]: d["active_subscribers"] for d in resp.json()["daily"] if d["tier"] == "plus"}
         # Only the re-subscriber counts, and only once despite two rows; abandoned is excluded.
@@ -158,10 +182,13 @@ async def test_subscriptions_snapshot_counts_segments(async_client):
         free = await _mk_user(db)  # registered, no paid sub
         user_ids += [paid, free]
         db.add(AnonChatUsage(ip=anon_ip, window_started_at=_TS, count=3))
+
+        headers, staff_id = await _mk_staff_headers(db)
+        user_ids.append(staff_id)
         await db.commit()
 
     try:
-        resp = await async_client.get("/stats/global/subscriptions")
+        resp = await async_client.get("/stats/global/subscriptions", headers=headers)
         assert resp.status_code == 200, resp.text
         body = resp.json()
         by_tier = {t["tier"]: t["active_subscribers"] for t in body["subscribers_by_tier"]}

--- a/tests/test_stats_users_window.py
+++ b/tests/test_stats_users_window.py
@@ -1,0 +1,41 @@
+from datetime import date
+
+from src.interfaces.stats import UsersWindow
+from src.services.stats import StatsService
+
+
+def test_rolling_users_stats_week_window():
+    # (day, identity) activity rows: u1 active Jan 1, u2 active Jan 3.
+    rows = [
+        (date(2026, 1, 1), "u1"),
+        (date(2026, 1, 3), "u2"),
+    ]
+    stats = StatsService._rolling_users_stats(
+        rows, start_date=date(2026, 1, 3), end_date=date(2026, 1, 5), window_days=7
+    )
+    # Jan 3: u1 (Jan 1 within trailing 7d) + u2 -> 2. Jan 4/5: still both within 7d -> 2.
+    assert [(d.date, d.active_users) for d in stats.daily_active_users] == [
+        ("2026-01-03", 2),
+        ("2026-01-04", 2),
+        ("2026-01-05", 2),
+    ]
+    # total_unique_users counts only activity INSIDE the requested range.
+    assert stats.total_unique_users == 1  # only u2 acted within Jan 3-5
+
+
+def test_rolling_users_stats_day_window_matches_plain_dau():
+    rows = [(date(2026, 1, 1), "u1"), (date(2026, 1, 1), "u2"), (date(2026, 1, 2), "u1")]
+    stats = StatsService._rolling_users_stats(
+        rows, start_date=date(2026, 1, 1), end_date=date(2026, 1, 2), window_days=1
+    )
+    assert [(d.date, d.active_users) for d in stats.daily_active_users] == [
+        ("2026-01-01", 2),
+        ("2026-01-02", 1),
+    ]
+    assert stats.total_unique_users == 2
+
+
+def test_users_window_enum_days():
+    assert UsersWindow.day.days == 1
+    assert UsersWindow.week.days == 7
+    assert UsersWindow.month.days == 30

--- a/tests/test_stats_users_window.py
+++ b/tests/test_stats_users_window.py
@@ -1,7 +1,65 @@
-from datetime import date
+from datetime import date, datetime, timedelta
 
+from src.interfaces.api_keys import ApiKeyType
 from src.interfaces.stats import UsersWindow
+from src.models.api_key import ApiKey
+from src.models.base import AsyncSessionLocal
+from src.models.inference_call import InferenceCall
 from src.services.stats import StatsService
+from src.services.users import get_or_create_user_by_wallet
+
+D = date(2020, 6, 10)
+PRE_RANGE = datetime.combine(D - timedelta(days=3), datetime.min.time().replace(hour=12))
+IN_RANGE = datetime.combine(D, datetime.min.time().replace(hour=12))
+
+U1 = "0xDA0200000000000000000000000000000000B001"
+U2 = "0xDA0200000000000000000000000000000000B002"
+
+
+def _inference_call(api_key_id, when: datetime) -> InferenceCall:
+    call = InferenceCall(api_key_id=api_key_id, credits_used=0.0, model_name="test-model")
+    call.used_at = when
+    return call
+
+
+async def _seed_fetch_start_extension() -> None:
+    async with AsyncSessionLocal() as db:
+        user1 = await get_or_create_user_by_wallet(db, U1)
+        user2 = await get_or_create_user_by_wallet(db, U2)
+        await db.flush()
+
+        u1_api = ApiKey(key=ApiKey.generate_key(), name="fse-u1-api", user_id=user1.id, type=ApiKeyType.api)
+        u2_api = ApiKey(key=ApiKey.generate_key(), name="fse-u2-api", user_id=user2.id, type=ApiKeyType.api)
+        db.add_all([u1_api, u2_api])
+        await db.flush()
+
+        db.add_all(
+            [
+                _inference_call(u1_api.id, PRE_RANGE),  # u1: D-3, before the queried range
+                _inference_call(u2_api.id, IN_RANGE),  # u2: D, inside the queried range
+            ]
+        )
+        await db.commit()
+
+
+async def test_get_inference_users_stats_fetch_start_extension():
+    await _seed_fetch_start_extension()
+
+    week = await StatsService._get_inference_users_stats(
+        ApiKeyType.api, start_date=D, end_date=D + timedelta(days=1), window=UsersWindow.week
+    )
+    by_day = {d.date: d.active_users for d in week.daily_active_users}
+    # D's trailing 7-day window reaches back to D-3, so both u1 (pre-range) and u2 count.
+    assert by_day[D.strftime("%Y-%m-%d")] == 2
+    # total_unique_users only counts activity inside [D, D+1] -> just u2.
+    assert week.total_unique_users == 1
+
+    day = await StatsService._get_inference_users_stats(
+        ApiKeyType.api, start_date=D, end_date=D + timedelta(days=1), window=UsersWindow.day
+    )
+    day_by_day = {d.date: d.active_users for d in day.daily_active_users}
+    # No fetch-start extension -> pre-range u1 not counted on D.
+    assert day_by_day[D.strftime("%Y-%m-%d")] == 1
 
 
 def test_rolling_users_stats_week_window():

--- a/tests/test_voucher_credits.py
+++ b/tests/test_voucher_credits.py
@@ -10,7 +10,6 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-from src.config import config
 from src.interfaces.credits import VoucherAddCreditsRequest
 from src.models.base import AsyncSessionLocal
 from src.models.credit_transaction import CreditTransaction
@@ -21,14 +20,8 @@ from src.services.users import get_or_create_user_by_wallet
 
 pytestmark = pytest.mark.asyncio
 
-PW = "test-voucher-pw"
 # A valid lowercase Base/EVM address (lowercase => no checksum requirement).
 ADDR = "0x000000000000000000000000000000000000dead"
-
-
-@pytest.fixture(autouse=True)
-def _allow_pw(monkeypatch):
-    monkeypatch.setattr(config, "VOUCHERS_PASSWORDS", [PW])
 
 
 async def _balance(user_id) -> float:
@@ -58,9 +51,7 @@ async def _cleanup_user(user_id):
 
 
 async def test_wallet_path_credits_wallet_user():
-    ok = await add_voucher_credits(
-        VoucherAddCreditsRequest(chain="base", address=ADDR, amount=7.0, password=PW)
-    )
+    ok = await add_voucher_credits(VoucherAddCreditsRequest(chain="base", address=ADDR, amount=7.0))
     assert ok is True
     async with AsyncSessionLocal() as db:
         user = await get_or_create_user_by_wallet(db, ADDR)
@@ -77,7 +68,7 @@ async def test_wallet_path_credits_wallet_user():
 async def test_email_unknown_account_is_rejected_and_creates_nothing():
     email = f"voucher-{uuid.uuid4().hex}@example.com"
     with pytest.raises(HTTPException) as exc:
-        await add_voucher_credits(VoucherAddCreditsRequest(email=email, amount=12.0, password=PW))
+        await add_voucher_credits(VoucherAddCreditsRequest(email=email, amount=12.0))
     assert exc.value.status_code == 404
     assert await _user_by_email(email) is None  # must not be created
 
@@ -90,7 +81,7 @@ async def test_email_path_credits_existing_user():
         await db.commit()
         user_id = user.id
     try:
-        ok = await add_voucher_credits(VoucherAddCreditsRequest(email=email.upper(), amount=3.0, password=PW))
+        ok = await add_voucher_credits(VoucherAddCreditsRequest(email=email.upper(), amount=3.0))
         assert ok is True
         # Same user (email normalised), not a duplicate.
         assert (await _user_by_email(email)).id == user_id
@@ -104,19 +95,14 @@ async def test_email_path_credits_existing_user():
 
 async def test_rejects_both_wallet_and_email():
     with pytest.raises(ValidationError):
-        VoucherAddCreditsRequest(chain="base", address=ADDR, email="a@b.com", amount=1.0, password=PW)
+        VoucherAddCreditsRequest(chain="base", address=ADDR, email="a@b.com", amount=1.0)
 
 
 async def test_rejects_neither_wallet_nor_email():
     with pytest.raises(ValidationError):
-        VoucherAddCreditsRequest(amount=1.0, password=PW)
+        VoucherAddCreditsRequest(amount=1.0)
 
 
 async def test_rejects_address_without_chain():
     with pytest.raises(ValidationError):
-        VoucherAddCreditsRequest(address=ADDR, amount=1.0, password=PW)
-
-
-async def test_rejects_bad_password():
-    with pytest.raises(ValidationError):
-        VoucherAddCreditsRequest(email="a@b.com", amount=1.0, password="nope")
+        VoucherAddCreditsRequest(address=ADDR, amount=1.0)


### PR DESCRIPTION
## Summary
Backend for the staff-only backoffice (used by libertai-analytics):

- `users.is_libertai_staff` flag (migration, manual SQL to set) exposed in `/auth/me`
- `require_staff` dependency; all 13 `/stats/global/*` routes and `POST /credits/vouchers` are now staff-gated (voucher body `password` removed; other voucher routes unchanged)
- `window=day|week|month` param on the users stats endpoints (rolling DAU/WAU/MAU, fetch window extended so early points aren't undercounted)
- New endpoints under `/stats/global/subscriptions/`:
  - `latest?limit=N` — most recent plan subscriptions with user label
  - `revenue` — Revolut-only, non-trial MRR (current, by tier, daily) via event replay (`created`/`activated`/`downgraded`/terminals — exact history, upgrades not double-counted)
  - `churn` — weekly new vs churned (upgrade replacements excluded)

## Notes
- MRR is nominal and currency-blind (EUR tiers are VAT-inclusive at the same nominal as USD)
- Companion PRs: libertai-analytics `feat/backoffice-refactor`, libertai-web-shared `feat/staff-flag` (SDK regen)

## Test plan
- 263 tests pass (new: staff gating 401/403/200, rolling-window math + DB integration, MRR replay incl. upgrade/downgrade boundaries, churn buckets)
- ruff clean; mypy at pre-existing baseline