### PR TITLE
feat: monthly cap on extra usage credits

### DIFF
--- a/alembic/versions/e5f6a7b8c9d0_users_monthly_extra_credit_cap.py
+++ b/alembic/versions/e5f6a7b8c9d0_users_monthly_extra_credit_cap.py
@@ -1,0 +1,26 @@
+"""users.monthly_extra_credit_cap (per-user monthly cap on extra-credit overflow spend)
+
+NULL means unlimited (the default). Enforced at the gateway whitelist, not at billing time.
+
+Revision ID: e5f6a7b8c9d0
+Revises: c3d4e5f6a7b9
+Create Date: 2026-07-09
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, None] = "c3d4e5f6a7b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("monthly_extra_credit_cap", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "monthly_extra_credit_cap")

--- a/src/interfaces/auth.py
+++ b/src/interfaces/auth.py
@@ -86,6 +86,7 @@ class CurrentUserResponse(BaseModel):
     avatar_url: str | None = None
     address: str | None = None
     is_libertai_staff: bool = False
+    monthly_extra_credit_cap: float | None = None
 
 
 class UpdateProfileRequest(BaseModel):
@@ -103,6 +104,16 @@ class UpdateProfileRequest(BaseModel):
         if len(trimmed) > 50:
             raise ValueError("display_name must be at most 50 characters")
         return trimmed
+
+    # Monthly cap (USD credits) on extra-credit overflow spend. Explicit null clears it
+    # (unlimited); omit the field to leave it untouched.
+    monthly_extra_credit_cap: float | None = None
+
+    @field_validator("monthly_extra_credit_cap")
+    def validate_cap(cls, value: float | None):
+        if value is not None and value <= 0:
+            raise ValueError("monthly_extra_credit_cap must be greater than 0")
+        return value
 
 
 class ExchangeRequest(BaseModel):

--- a/src/interfaces/auth.py
+++ b/src/interfaces/auth.py
@@ -1,3 +1,5 @@
+import math
+
 from libertai_utils.chains.index import is_address_valid
 from libertai_utils.interfaces.blockchain import LibertaiChain
 from pydantic import BaseModel, ValidationInfo, field_validator
@@ -111,8 +113,8 @@ class UpdateProfileRequest(BaseModel):
 
     @field_validator("monthly_extra_credit_cap")
     def validate_cap(cls, value: float | None):
-        if value is not None and value <= 0:
-            raise ValueError("monthly_extra_credit_cap must be greater than 0")
+        if value is not None and (not math.isfinite(value) or value <= 0):
+            raise ValueError("monthly_extra_credit_cap must be a finite number greater than 0")
         return value
 
 

--- a/src/interfaces/payments.py
+++ b/src/interfaces/payments.py
@@ -95,6 +95,9 @@ class SubscriptionResponse(BaseModel):
     weekly_limit: float = 0.0
     weekly_resets_at: UtcDatetime | None = None
     prepaid_balance: float = 0.0
+    # Monthly extra-credit spend cap (None = unlimited) and attempted overflow this calendar month.
+    monthly_extra_credit_cap: float | None = None
+    extra_credits_used_this_month: float = 0.0
 
 
 class CancelResponse(BaseModel):

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import TIMESTAMP, UUID, Boolean, String, func, select
+from sqlalchemy import TIMESTAMP, UUID, Boolean, Float, String, func, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.models.base import Base, AsyncSessionLocal
@@ -26,6 +26,8 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=func.current_timestamp())
     # Grants access to the staff backoffice (analytics + admin actions). Set manually via SQL.
     is_libertai_staff: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Monthly cap (USD credits) on overflow spend beyond entitlement windows. NULL = unlimited.
+    monthly_extra_credit_cap: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     # Legacy wallet address. Identity moved to wallet_connections; kept (nullable, unique) for one
     # release as a rollback hatch and so existing address-based FKs resolve until the FK swap.

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -159,6 +159,7 @@ async def get_me(user: User = Depends(get_current_user)) -> CurrentUserResponse:
         avatar_url=user.avatar_url,
         address=user.address,
         is_libertai_staff=user.is_libertai_staff,
+        monthly_extra_credit_cap=user.monthly_extra_credit_cap,
     )
 
 
@@ -166,9 +167,11 @@ async def get_me(user: User = Depends(get_current_user)) -> CurrentUserResponse:
 async def update_me(
     request: UpdateProfileRequest, user: User = Depends(get_current_user)
 ) -> CurrentUserResponse:
-    """Update the authenticated user's editable profile (display name)."""
+    """Update the authenticated user's editable profile (display name, monthly extra-credit cap)."""
     async with AsyncSessionLocal() as db:
-        updated = await update_user_profile(db, user.id, request.display_name)
+        updated = await update_user_profile(
+            db, user.id, request.model_dump(exclude_unset=True, include={"display_name", "monthly_extra_credit_cap"})
+        )
         await db.commit()
         return CurrentUserResponse(
             id=str(updated.id),
@@ -177,6 +180,7 @@ async def update_me(
             avatar_url=updated.avatar_url,
             address=updated.address,
             is_libertai_staff=updated.is_libertai_staff,
+            monthly_extra_credit_cap=updated.monthly_extra_credit_cap,
         )
 
 

--- a/src/routes/payments/payments.py
+++ b/src/routes/payments/payments.py
@@ -419,6 +419,8 @@ async def get_subscription(user: User = Depends(get_current_user)) -> Subscripti
         weekly_limit=allowance.weekly_limit,
         weekly_resets_at=allowance.weekly_resets_at,
         prepaid_balance=allowance.prepaid_balance,
+        monthly_extra_credit_cap=allowance.monthly_extra_credit_cap,
+        extra_credits_used_this_month=allowance.extra_credits_used_this_month,
     )
 
 

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -12,6 +12,7 @@ from src.interfaces.api_keys import ApiKey, FullApiKey, ApiKeyType
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.inference_call import InferenceCall
+from src.models.user import User
 from src.services.api_key_pool import ApiKeyPoolService
 from src.services.credit import CreditService
 from src.services.entitlement import (
@@ -21,7 +22,9 @@ from src.services.entitlement import (
     active_tiers_by_users,
     compute_source,
     current_month_bounds,
+    effective_prepaid,
     get_allowance_state,
+    month_overflow_by_users,
     open_windows,
     window_usage_by_users,
 )
@@ -559,6 +562,20 @@ class ApiKeyService:
                 weekly_usage = await window_usage_by_users(db, user_ids, WINDOW_WEEKLY, now)
                 active_tiers = await active_tiers_by_users(db, user_ids)
 
+                caps: dict[uuid.UUID, float] = {}
+                cap_overflow: dict[uuid.UUID, float] = {}
+                if user_ids:
+                    cap_rows = (
+                        await db.execute(
+                            select(User.id, User.monthly_extra_credit_cap).where(
+                                User.id.in_(user_ids),
+                                User.monthly_extra_credit_cap.is_not(None),
+                            )
+                        )
+                    ).all()
+                    caps = {row[0]: float(row[1]) for row in cap_rows}
+                    cap_overflow = await month_overflow_by_users(db, set(caps), now)
+
                 # Pre-fetch current month usage for API keys with monthly limits
                 api_keys_with_limits = [
                     k for k in api_keys if k.type in chargeable_api_types and k.monthly_limit is not None
@@ -653,7 +670,11 @@ class ApiKeyService:
                             tier,
                             window_5h_usage.get(key.user_id, 0.0),
                             weekly_usage.get(key.user_id, 0.0),
-                            balances.get(key.user_id, 0.0),
+                            effective_prepaid(
+                                balances.get(key.user_id, 0.0),
+                                caps.get(key.user_id),
+                                cap_overflow.get(key.user_id, 0.0),
+                            ),
                         )
                         if source == "blocked":
                             continue

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -613,7 +613,10 @@ class ApiKeyService:
                     now = datetime.now()
                     key_ids_by_window: dict[int, list[uuid.UUID]] = {}
                     for k in liberclaw_keys:
-                        tier_config = LIBERCLAW_TIERS.get(k.liberclaw_user.tier, LIBERCLAW_TIERS["free"])
+                        lc_user = k.liberclaw_user
+                        if lc_user is None:
+                            continue
+                        tier_config = LIBERCLAW_TIERS.get(lc_user.tier, LIBERCLAW_TIERS["free"])
                         key_ids_by_window.setdefault(tier_config["rolling_window_days"], []).append(k.id)
                     for window_days, key_ids in key_ids_by_window.items():
                         cutoff = now - timedelta(days=window_days)

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -750,7 +750,8 @@ class ApiKeyService:
                 if chargeable_user_id is not None:
                     # Open/reset this user's fixed windows so usage accrues against them.
                     await open_windows(db, chargeable_user_id, now)
-                    state = await get_allowance_state(db, chargeable_user_id, now)
+                    # Billing split only needs the window fields — skip the cap queries.
+                    state = await get_allowance_state(db, chargeable_user_id, now, include_cap=False)
                     remaining_5h = max(0.0, state.window_5h_limit - state.window_5h_used)
                     remaining_weekly = max(0.0, state.weekly_limit - state.weekly_used)
                     tier_covered = min(credits_used, remaining_5h, remaining_weekly)

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -20,6 +20,7 @@ from src.services.entitlement import (
     WINDOW_WEEKLY,
     active_tiers_by_users,
     compute_source,
+    current_month_bounds,
     get_allowance_state,
     open_windows,
     window_usage_by_users,
@@ -564,9 +565,7 @@ class ApiKeyService:
                 ]
                 monthly_usage: dict[uuid.UUID, float] = {}
                 if api_keys_with_limits:
-                    now = datetime.now()
-                    first_day = datetime(now.year, now.month, 1)
-                    next_month = datetime(now.year + (now.month // 12), ((now.month % 12) + 1), 1)
+                    first_day, next_month = current_month_bounds(datetime.now())
                     limit_key_ids = [k.id for k in api_keys_with_limits]
 
                     usage_rows = (

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -582,7 +582,7 @@ class ApiKeyService:
                 ]
                 monthly_usage: dict[uuid.UUID, float] = {}
                 if api_keys_with_limits:
-                    first_day, next_month = current_month_bounds(datetime.now())
+                    first_day, next_month = current_month_bounds(now)
                     limit_key_ids = [k.id for k in api_keys_with_limits]
 
                     usage_rows = (

--- a/src/services/entitlement.py
+++ b/src/services/entitlement.py
@@ -281,7 +281,8 @@ async def get_allowance_state(
 
     user = await db.get(User, user_id)
     cap = user.monthly_extra_credit_cap if user else None
-    month_overflow = (await month_overflow_by_users(db, {user_id}, now)).get(user_id, 0.0)
+    # Skip the month aggregate for uncapped users: this runs per inference call.
+    month_overflow = (await month_overflow_by_users(db, {user_id}, now)).get(user_id, 0.0) if cap is not None else 0.0
 
     source = compute_source(tier, usage_5h, usage_weekly, effective_prepaid(prepaid, cap, month_overflow))
 

--- a/src/services/entitlement.py
+++ b/src/services/entitlement.py
@@ -268,8 +268,11 @@ async def active_tiers_by_users(db: AsyncSession, user_ids: set[uuid.UUID]) -> d
 
 
 async def get_allowance_state(
-    db: AsyncSession, user_id: uuid.UUID, now: datetime | None = None
+    db: AsyncSession, user_id: uuid.UUID, now: datetime | None = None, include_cap: bool = True
 ) -> AllowanceState:
+    """``include_cap=False`` skips the cap fetch + month-overflow aggregate for callers
+    that only need the window fields (the per-call billing split) — the cap then reads
+    as unlimited in the returned state."""
     now = now or datetime.now()
     tier = get_tier(await get_active_tier(db, user_id))
 
@@ -279,10 +282,14 @@ async def get_allowance_state(
     usage_weekly = await _usage_since(db, user_id, window_weekly.started_at) if window_weekly else 0.0
     prepaid = await _prepaid_balance(db, user_id)
 
-    user = await db.get(User, user_id)
-    cap = user.monthly_extra_credit_cap if user else None
-    # Skip the month aggregate for uncapped users: this runs per inference call.
-    month_overflow = (await month_overflow_by_users(db, {user_id}, now)).get(user_id, 0.0) if cap is not None else 0.0
+    cap: float | None = None
+    month_overflow = 0.0
+    if include_cap:
+        user = await db.get(User, user_id)
+        cap = user.monthly_extra_credit_cap if user else None
+        # Skip the month aggregate for uncapped users: this runs on request paths.
+        if cap is not None:
+            month_overflow = (await month_overflow_by_users(db, {user_id}, now)).get(user_id, 0.0)
 
     source = compute_source(tier, usage_5h, usage_weekly, effective_prepaid(prepaid, cap, month_overflow))
 

--- a/src/services/entitlement.py
+++ b/src/services/entitlement.py
@@ -25,6 +25,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func as sql_func
 
+from src.config import config
 from src.interfaces.api_keys import ApiKeyType
 from src.interfaces.credits import CreditTransactionStatus
 from src.models.api_key import ApiKey as ApiKeyDB
@@ -32,6 +33,7 @@ from src.models.credit_transaction import CreditTransaction
 from src.models.entitlement_window import EntitlementWindow
 from src.models.inference_call import InferenceCall
 from src.models.plan_subscription import PlanSubscription
+from src.models.user import User
 from src.subscription_tiers import DEFAULT_TIER, TierConfig, get_tier
 
 # Minimum prepaid balance required to cover an inference call once tier windows
@@ -52,6 +54,20 @@ WINDOW_DURATIONS: dict[str, timedelta] = {
 CHARGEABLE_KEY_TYPES = (ApiKeyType.api, ApiKeyType.cli, ApiKeyType.chat)
 
 
+def current_month_bounds(now: datetime) -> tuple[datetime, datetime]:
+    """[first day, first day of next month) — the boundary used by all monthly caps."""
+    first_day = datetime(now.year, now.month, 1)
+    next_month = datetime(now.year + (now.month // 12), ((now.month % 12) + 1), 1)
+    return first_day, next_month
+
+
+def effective_prepaid(prepaid: float, cap: float | None, month_overflow: float) -> float:
+    """Prepaid balance usable this month given the user's extra-credit cap (None = uncapped)."""
+    if cap is None:
+        return prepaid
+    return min(prepaid, max(0.0, cap - month_overflow))
+
+
 @dataclass
 class AllowanceState:
     allowed: bool
@@ -65,6 +81,9 @@ class AllowanceState:
     # When each active window resets (None if no active window of that kind).
     window_5h_resets_at: datetime | None
     weekly_resets_at: datetime | None
+    # Monthly extra-credit cap (None = unlimited) and attempted overflow spend this calendar month.
+    monthly_extra_credit_cap: float | None = None
+    extra_credits_used_this_month: float = 0.0
 
 
 def compute_source(tier: TierConfig, usage_5h: float, usage_weekly: float, prepaid: float) -> str:
@@ -200,6 +219,39 @@ async def window_usage_by_users(
     return {row[0]: float(row[1]) for row in rows}
 
 
+async def month_overflow_by_users(
+    db: AsyncSession, user_ids: set[uuid.UUID], now: datetime
+) -> dict[uuid.UUID, float]:
+    """Batched attempted-overflow spend (credits_used - tier_credits_used) per user this
+    calendar month, across chargeable keys. Rows record full overflow even when the partial
+    deduction captured less, so this is conservative. Absent users => 0.
+    """
+    if not user_ids:
+        return {}
+    first_day, next_month = current_month_bounds(now)
+    conditions = [
+        ApiKeyDB.user_id.in_(user_ids),
+        ApiKeyDB.type.in_(CHARGEABLE_KEY_TYPES),
+        InferenceCall.used_at >= first_day,
+        InferenceCall.used_at < next_month,
+    ]
+    # The shared anonymous chat key is chargeable-typed but never user-billed.
+    if config.LIBERTAI_CHAT_API_KEY:
+        conditions.append(ApiKeyDB.key != config.LIBERTAI_CHAT_API_KEY)
+    rows = (
+        await db.execute(
+            select(
+                ApiKeyDB.user_id,
+                sql_func.coalesce(sql_func.sum(InferenceCall.credits_used - InferenceCall.tier_credits_used), 0.0),
+            )
+            .join(InferenceCall, InferenceCall.api_key_id == ApiKeyDB.id)
+            .where(*conditions)
+            .group_by(ApiKeyDB.user_id)
+        )
+    ).all()
+    return {row[0]: float(row[1]) for row in rows}
+
+
 async def active_tiers_by_users(db: AsyncSession, user_ids: set[uuid.UUID]) -> dict[uuid.UUID, str]:
     """Batched active-subscription tier per user (absent => free)."""
     if not user_ids:
@@ -227,7 +279,11 @@ async def get_allowance_state(
     usage_weekly = await _usage_since(db, user_id, window_weekly.started_at) if window_weekly else 0.0
     prepaid = await _prepaid_balance(db, user_id)
 
-    source = compute_source(tier, usage_5h, usage_weekly, prepaid)
+    user = await db.get(User, user_id)
+    cap = user.monthly_extra_credit_cap if user else None
+    month_overflow = (await month_overflow_by_users(db, {user_id}, now)).get(user_id, 0.0)
+
+    source = compute_source(tier, usage_5h, usage_weekly, effective_prepaid(prepaid, cap, month_overflow))
 
     return AllowanceState(
         allowed=source != "blocked",
@@ -240,4 +296,6 @@ async def get_allowance_state(
         source=source,
         window_5h_resets_at=window_5h.expires_at if window_5h else None,
         weekly_resets_at=window_weekly.expires_at if window_weekly else None,
+        monthly_extra_credit_cap=cap,
+        extra_credits_used_this_month=month_overflow,
     )

--- a/src/services/payments/credit_subscription.py
+++ b/src/services/payments/credit_subscription.py
@@ -134,6 +134,8 @@ class CreditSubscriptionService:
 
         if not is_upgrade(sub.tier, new_tier):
             raise ValueError("Not an upgrade")
+        if sub.current_period_end is None or sub.current_period_start is None:
+            raise ValueError("Subscription has no active billing period")
         span = (sub.current_period_end - sub.current_period_start).total_seconds()
         remaining = max(0.0, (sub.current_period_end - now).total_seconds())
         frac = remaining / span if span > 0 else 1.0
@@ -263,7 +265,7 @@ class CreditSubscriptionService:
         # so cycles don't drift later by up to the cron interval on every renewal.
         # If the cron was down for more than a full cycle, re-anchor at now instead
         # of back-billing an already-elapsed period.
-        period_start = sub.current_period_end
+        period_start = sub.current_period_end or now
         period_end = period_start + relativedelta(months=1)
         if period_end <= now:
             period_start, period_end = now, now + relativedelta(months=1)

--- a/src/services/users.py
+++ b/src/services/users.py
@@ -140,11 +140,13 @@ async def link_wallet(db: AsyncSession, user: User, address: str, chain: str | N
     return wallet
 
 
-async def update_user_profile(db: AsyncSession, user_id: uuid.UUID, display_name: str | None) -> User:
-    """Update the user's editable profile fields (currently just the display name)."""
+async def update_user_profile(db: AsyncSession, user_id: uuid.UUID, updates: dict) -> User:
+    """Partial update of the user's editable profile fields (only keys present are assigned)."""
     user = await db.get(User, user_id)
     if user is None:
         raise ValueError(f"User {user_id} not found")
-    user.display_name = display_name
+    for field in ("display_name", "monthly_extra_credit_cap"):
+        if field in updates:
+            setattr(user, field, updates[field])
     await db.flush()
     return user

--- a/src/services/x402.py
+++ b/src/services/x402.py
@@ -57,7 +57,7 @@ class X402Service:
                 }
             elif "image" in model.pricing:
                 image_price = model.pricing["image"]
-                if isinstance(image_price, (TextPricing, EmbeddingPricing)):
+                if not isinstance(image_price, (int, float)):
                     continue
                 prices[model.id] = {
                     "price_per_image": float(image_price),

--- a/tests/test_admin_list_enforcement.py
+++ b/tests/test_admin_list_enforcement.py
@@ -26,7 +26,7 @@ from src.services.entitlement import WINDOW_5H
 pytestmark = pytest.mark.asyncio
 
 
-async def _setup(*, usage=None, window="active", prepaid=0.0, tier=None):
+async def _setup(*, usage=None, window="active", prepaid=0.0, tier=None, cap=None, overflow=0.0):
     """Create a user + api key with optional usage in an active/expired 5h window.
 
     ``window`` controls the 5h window state when ``usage`` is given:
@@ -37,6 +37,7 @@ async def _setup(*, usage=None, window="active", prepaid=0.0, tier=None):
     now = datetime.now()
     async with AsyncSessionLocal() as db:
         user = User(email=f"enf-{uuid.uuid4().hex}@example.com")
+        user.monthly_extra_credit_cap = cap
         db.add(user)
         await db.flush()
         key = ApiKeyDB(key=ApiKeyDB.generate_key(), name=uuid.uuid4().hex, user_id=user.id, type=ApiKeyType.api)
@@ -51,6 +52,10 @@ async def _setup(*, usage=None, window="active", prepaid=0.0, tier=None):
             # Seeded usage simulates tier-covered calls (counts against the window).
             call = InferenceCall(api_key_id=key.id, credits_used=usage, model_name="m", tier_credits_used=usage)
             call.used_at = used_at
+            db.add(call)
+        if overflow:
+            call = InferenceCall(api_key_id=key.id, credits_used=overflow, model_name="m", tier_credits_used=0.0)
+            call.used_at = now - timedelta(minutes=10)
             db.add(call)
         if prepaid:
             db.add(
@@ -213,6 +218,49 @@ async def test_liberclaw_usage_outside_window_ignored():
         assert key in await ApiKeyService.get_admin_all_api_keys()
     finally:
         await _cleanup_liberclaw(lc_id)
+
+
+async def test_cap_reached_excludes_key_when_window_exhausted():
+    # Free 5h window exhausted; prepaid exists but this month's overflow >= cap.
+    user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=2.0, overflow=3.0)
+    try:
+        assert key not in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_cap_not_reached_keeps_key():
+    user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=10.0, overflow=3.0)
+    try:
+        assert key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_cap_reached_but_window_open_keeps_key():
+    # Windows have room -> "tier" source; the cap only governs the prepaid path.
+    user_id, key = await _setup(usage=0.1, window="active", prepaid=50.0, cap=2.0, overflow=3.0)
+    try:
+        assert key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_no_cap_unlimited_overflow_keeps_key():
+    user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=None, overflow=999.0)
+    try:
+        assert key in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_balance_still_binds_below_cap():
+    # Cap has room but prepaid < PREPAID_MIN -> still blocked.
+    user_id, key = await _setup(usage=0.5, window="active", prepaid=0.01, cap=100.0, overflow=1.0)
+    try:
+        assert key not in await ApiKeyService.get_admin_all_api_keys()
+    finally:
+        await _cleanup(user_id)
 
 
 async def _balance(user_id) -> float:

--- a/tests/test_extra_credit_cap.py
+++ b/tests/test_extra_credit_cap.py
@@ -232,6 +232,10 @@ def test_update_request_rejects_non_positive_cap():
         UpdateProfileRequest(monthly_extra_credit_cap=0)
     with pytest.raises(pydantic.ValidationError):
         UpdateProfileRequest(monthly_extra_credit_cap=-5.0)
+    with pytest.raises(pydantic.ValidationError):
+        UpdateProfileRequest(monthly_extra_credit_cap=float("nan"))
+    with pytest.raises(pydantic.ValidationError):
+        UpdateProfileRequest(monthly_extra_credit_cap=float("inf"))
     assert UpdateProfileRequest(monthly_extra_credit_cap=12.5).monthly_extra_credit_cap == 12.5
     assert UpdateProfileRequest(monthly_extra_credit_cap=None).monthly_extra_credit_cap is None
 

--- a/tests/test_extra_credit_cap.py
+++ b/tests/test_extra_credit_cap.py
@@ -6,10 +6,12 @@ Runs against the committed DB with real ``datetime.now()``; each test cleans up 
 import uuid
 from datetime import datetime, timedelta
 
+import pydantic
 import pytest
 from sqlalchemy import delete
 
 from src.interfaces.api_keys import ApiKeyType
+from src.interfaces.auth import UpdateProfileRequest
 from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
@@ -25,6 +27,7 @@ from src.services.entitlement import (
     get_allowance_state,
     month_overflow_by_users,
 )
+from src.services.users import update_user_profile
 
 pytestmark = pytest.mark.asyncio
 
@@ -219,5 +222,46 @@ async def test_allowance_state_no_cap_unchanged():
             state = await get_allowance_state(db, user_id)
         assert state.source == "prepaid"
         assert state.monthly_extra_credit_cap is None
+    finally:
+        await _cleanup(user_id)
+
+
+def test_update_request_rejects_non_positive_cap():
+    with pytest.raises(pydantic.ValidationError):
+        UpdateProfileRequest(monthly_extra_credit_cap=0)
+    with pytest.raises(pydantic.ValidationError):
+        UpdateProfileRequest(monthly_extra_credit_cap=-5.0)
+    assert UpdateProfileRequest(monthly_extra_credit_cap=12.5).monthly_extra_credit_cap == 12.5
+    assert UpdateProfileRequest(monthly_extra_credit_cap=None).monthly_extra_credit_cap is None
+
+
+def test_update_request_partial_dump():
+    # exclude_unset is what keeps a cap-only PATCH from clobbering display_name (and vice versa).
+    req = UpdateProfileRequest.model_validate({"monthly_extra_credit_cap": 5.0})
+    assert req.model_dump(exclude_unset=True) == {"monthly_extra_credit_cap": 5.0}
+    req = UpdateProfileRequest.model_validate({"display_name": "Ada"})
+    assert req.model_dump(exclude_unset=True) == {"display_name": "Ada"}
+    req = UpdateProfileRequest.model_validate({"monthly_extra_credit_cap": None})
+    assert req.model_dump(exclude_unset=True) == {"monthly_extra_credit_cap": None}
+
+
+async def test_update_user_profile_partial():
+    user_id, _ = await _setup()
+    try:
+        async with AsyncSessionLocal() as db:
+            await update_user_profile(db, user_id, {"display_name": "Ada", "monthly_extra_credit_cap": 7.5})
+            await db.commit()
+        async with AsyncSessionLocal() as db:
+            user = await db.get(User, user_id)
+            assert user.display_name == "Ada"
+            assert user.monthly_extra_credit_cap == 7.5
+        # Cap-only update leaves display_name alone.
+        async with AsyncSessionLocal() as db:
+            await update_user_profile(db, user_id, {"monthly_extra_credit_cap": None})
+            await db.commit()
+        async with AsyncSessionLocal() as db:
+            user = await db.get(User, user_id)
+            assert user.display_name == "Ada"
+            assert user.monthly_extra_credit_cap is None
     finally:
         await _cleanup(user_id)

--- a/tests/test_extra_credit_cap.py
+++ b/tests/test_extra_credit_cap.py
@@ -30,8 +30,6 @@ from src.services.entitlement import (
 )
 from src.services.users import update_user_profile
 
-pytestmark = pytest.mark.asyncio
-
 
 def _last_month(now: datetime) -> datetime:
     # Explicit month arithmetic — timedelta(days=30) straddles boundaries on the 1st.
@@ -147,6 +145,24 @@ async def test_allowance_state_cap_reached_blocks_prepaid():
         assert state.monthly_extra_credit_cap == pytest.approx(2.0)
         # exhaust_windows seeds 10.0 tier-covered (0 overflow) + the explicit 3.0 overflow call
         assert state.extra_credits_used_this_month == pytest.approx(3.0)
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_allowance_state_include_cap_false_skips_cap():
+    # Billing-split callers only consume window fields; the cap must not run its queries there.
+    now = datetime.now()
+    user_id, _ = await _setup(
+        prepaid=50.0, cap=2.0, exhaust_windows=True,
+        overflow_calls=[(3.0, 0.0, now - timedelta(minutes=5))],
+    )
+    try:
+        async with AsyncSessionLocal() as db:
+            state = await get_allowance_state(db, user_id, include_cap=False)
+        assert state.monthly_extra_credit_cap is None
+        assert state.extra_credits_used_this_month == 0.0
+        assert state.source == "prepaid"  # cap ignored on this path
+        assert state.window_5h_used == pytest.approx(10.0)
     finally:
         await _cleanup(user_id)
 

--- a/tests/test_extra_credit_cap.py
+++ b/tests/test_extra_credit_cap.py
@@ -1,0 +1,223 @@
+"""Monthly extra-credit cap: overflow aggregation + cap-aware allowance state.
+
+Runs against the committed DB with real ``datetime.now()``; each test cleans up its rows.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import delete
+
+from src.interfaces.api_keys import ApiKeyType
+from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.models.api_key import ApiKey as ApiKeyDB
+from src.models.base import AsyncSessionLocal
+from src.models.credit_transaction import CreditTransaction
+from src.models.entitlement_window import EntitlementWindow
+from src.models.inference_call import InferenceCall
+from src.models.user import User
+from src.services.entitlement import (
+    WINDOW_5H,
+    WINDOW_WEEKLY,
+    current_month_bounds,
+    effective_prepaid,
+    get_allowance_state,
+    month_overflow_by_users,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _last_month(now: datetime) -> datetime:
+    # Explicit month arithmetic — timedelta(days=30) straddles boundaries on the 1st.
+    year, month = (now.year - 1, 12) if now.month == 1 else (now.year, now.month - 1)
+    return datetime(year, month, 15)
+
+
+async def _setup(*, prepaid=0.0, cap=None, overflow_calls=(), exhaust_windows=False):
+    """User + api key, with optional prepaid balance, cap, and overflow inference calls.
+
+    ``overflow_calls``: list of (credits_used, tier_credits_used, used_at) tuples.
+    ``exhaust_windows``: open both windows now and seed tier usage above the free limits
+    (free tier: 0.5 per 5h window) so the next call must come from prepaid.
+    Returns (user_id, key_id).
+    """
+    now = datetime.now()
+    async with AsyncSessionLocal() as db:
+        user = User(email=f"cap-{uuid.uuid4().hex}@example.com")
+        user.monthly_extra_credit_cap = cap
+        db.add(user)
+        await db.flush()
+        key = ApiKeyDB(key=ApiKeyDB.generate_key(), name=uuid.uuid4().hex, user_id=user.id, type=ApiKeyType.api)
+        db.add(key)
+        await db.flush()
+        if exhaust_windows:
+            for kind in (WINDOW_5H, WINDOW_WEEKLY):
+                db.add(
+                    EntitlementWindow(
+                        user_id=user.id, kind=kind,
+                        started_at=now - timedelta(hours=1), expires_at=now + timedelta(hours=4),
+                    )
+                )
+            call = InferenceCall(api_key_id=key.id, credits_used=10.0, model_name="m", tier_credits_used=10.0)
+            call.used_at = now - timedelta(minutes=30)
+            db.add(call)
+        for credits_used, tier_credits_used, used_at in overflow_calls:
+            call = InferenceCall(
+                api_key_id=key.id, credits_used=credits_used, model_name="m",
+                tier_credits_used=tier_credits_used,
+            )
+            call.used_at = used_at
+            db.add(call)
+        if prepaid:
+            db.add(
+                CreditTransaction(
+                    user_id=user.id, amount=prepaid, amount_left=prepaid,
+                    provider=CreditTransactionProvider.revolut, status=CreditTransactionStatus.completed,
+                )
+            )
+        await db.commit()
+        return user.id, key.id
+
+
+async def _cleanup(user_id):
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(EntitlementWindow).where(EntitlementWindow.user_id == user_id))
+        await db.execute(delete(CreditTransaction).where(CreditTransaction.user_id == user_id))
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.user_id == user_id))
+        await db.execute(delete(User).where(User.id == user_id))
+        await db.commit()
+
+
+def test_current_month_bounds():
+    first, nxt = current_month_bounds(datetime(2026, 7, 9, 13, 37))
+    assert first == datetime(2026, 7, 1)
+    assert nxt == datetime(2026, 8, 1)
+    first, nxt = current_month_bounds(datetime(2026, 12, 31, 23, 59))
+    assert first == datetime(2026, 12, 1)
+    assert nxt == datetime(2027, 1, 1)
+
+
+def test_effective_prepaid():
+    assert effective_prepaid(100.0, None, 999.0) == 100.0  # no cap -> raw balance
+    assert effective_prepaid(100.0, 20.0, 5.0) == 15.0  # cap remaining binds
+    assert effective_prepaid(10.0, 20.0, 5.0) == 10.0  # balance binds
+    assert effective_prepaid(100.0, 20.0, 25.0) == 0.0  # overshoot floors at 0
+
+
+async def test_month_overflow_sums_current_month_only():
+    now = datetime.now()
+    user_id, _ = await _setup(
+        overflow_calls=[
+            (1.0, 0.25, now - timedelta(minutes=5)),  # 0.75 overflow this month
+            (2.0, 0.0, now - timedelta(minutes=10)),  # 2.0 overflow this month
+            (5.0, 0.0, _last_month(now)),  # last month -> excluded
+        ]
+    )
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await month_overflow_by_users(db, {user_id}, now)
+        assert result.get(user_id, 0.0) == pytest.approx(2.75)
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_month_overflow_empty_input():
+    async with AsyncSessionLocal() as db:
+        assert await month_overflow_by_users(db, set(), datetime.now()) == {}
+
+
+async def test_allowance_state_cap_reached_blocks_prepaid():
+    now = datetime.now()
+    user_id, _ = await _setup(
+        prepaid=50.0, cap=2.0, exhaust_windows=True,
+        overflow_calls=[(3.0, 0.0, now - timedelta(minutes=5))],  # 3.0 overflow >= 2.0 cap
+    )
+    try:
+        async with AsyncSessionLocal() as db:
+            state = await get_allowance_state(db, user_id)
+        assert state.source == "blocked"
+        assert state.allowed is False
+        assert state.prepaid_balance == pytest.approx(50.0)  # raw, not capped
+        assert state.monthly_extra_credit_cap == pytest.approx(2.0)
+        # exhaust_windows seeds 10.0 tier-covered (0 overflow) + the explicit 3.0 overflow call
+        assert state.extra_credits_used_this_month == pytest.approx(3.0)
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_allowance_state_cap_not_reached_allows_prepaid():
+    now = datetime.now()
+    user_id, _ = await _setup(
+        prepaid=50.0, cap=10.0, exhaust_windows=True,
+        overflow_calls=[(3.0, 0.0, now - timedelta(minutes=5))],
+    )
+    try:
+        async with AsyncSessionLocal() as db:
+            state = await get_allowance_state(db, user_id)
+        assert state.source == "prepaid"
+        assert state.allowed is True
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_allowance_state_cap_irrelevant_while_windows_open():
+    user_id, _ = await _setup(prepaid=50.0, cap=0.01)  # tiny cap, fresh windows
+    try:
+        async with AsyncSessionLocal() as db:
+            state = await get_allowance_state(db, user_id)
+        assert state.source == "tier"
+        assert state.allowed is True
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_month_overflow_excludes_shared_chat_key():
+    from src.config import config
+
+    if not config.LIBERTAI_CHAT_API_KEY:
+        pytest.skip("LIBERTAI_CHAT_API_KEY not configured")
+    now = datetime.now()
+    async with AsyncSessionLocal() as db:
+        from sqlalchemy import select
+
+        exists = (
+            await db.execute(select(ApiKeyDB.id).where(ApiKeyDB.key == config.LIBERTAI_CHAT_API_KEY))
+        ).scalar_one_or_none()
+    if exists is not None:
+        pytest.skip("shared chat key already present in this DB (key column is unique)")
+    user_id, _ = await _setup(overflow_calls=[(1.0, 0.0, now - timedelta(minutes=5))])
+    try:
+        # Attach a key whose value IS the shared anonymous chat key to the same user;
+        # its calls must not count against the user's cap.
+        async with AsyncSessionLocal() as db:
+            shared = ApiKeyDB(
+                key=config.LIBERTAI_CHAT_API_KEY, name=uuid.uuid4().hex, user_id=user_id, type=ApiKeyType.chat
+            )
+            db.add(shared)
+            await db.flush()
+            call = InferenceCall(api_key_id=shared.id, credits_used=42.0, model_name="m", tier_credits_used=0.0)
+            call.used_at = now - timedelta(minutes=5)
+            db.add(call)
+            await db.commit()
+        async with AsyncSessionLocal() as db:
+            result = await month_overflow_by_users(db, {user_id}, now)
+        assert result.get(user_id, 0.0) == pytest.approx(1.0)
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_allowance_state_no_cap_unchanged():
+    now = datetime.now()
+    user_id, _ = await _setup(
+        prepaid=50.0, cap=None, exhaust_windows=True,
+        overflow_calls=[(999.0, 0.0, now - timedelta(minutes=5))],
+    )
+    try:
+        async with AsyncSessionLocal() as db:
+            state = await get_allowance_state(db, user_id)
+        assert state.source == "prepaid"
+        assert state.monthly_extra_credit_cap is None
+    finally:
+        await _cleanup(user_id)

--- a/tests/test_extra_credit_cap.py
+++ b/tests/test_extra_credit_cap.py
@@ -13,6 +13,7 @@ from sqlalchemy import delete
 from src.interfaces.api_keys import ApiKeyType
 from src.interfaces.auth import UpdateProfileRequest
 from src.interfaces.credits import CreditTransactionProvider, CreditTransactionStatus
+from src.interfaces.payments import SubscriptionResponse
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.credit_transaction import CreditTransaction
@@ -265,3 +266,16 @@ async def test_update_user_profile_partial():
             assert user.monthly_extra_credit_cap is None
     finally:
         await _cleanup(user_id)
+
+
+def test_subscription_response_carries_cap_fields():
+    resp = SubscriptionResponse(
+        tier="free", has_subscription=False,
+        monthly_extra_credit_cap=20.0, extra_credits_used_this_month=3.5,
+    )
+    assert resp.monthly_extra_credit_cap == 20.0
+    assert resp.extra_credits_used_this_month == 3.5
+    # Defaults keep older clients working.
+    resp = SubscriptionResponse(tier="free", has_subscription=False)
+    assert resp.monthly_extra_credit_cap is None
+    assert resp.extra_credits_used_this_month == 0.0

--- a/tests/test_profile_update.py
+++ b/tests/test_profile_update.py
@@ -18,7 +18,7 @@ async def test_update_display_name_persists():
     user_id = await _make_user("name-update@example.com")
 
     async with AsyncSessionLocal() as db:
-        updated = await update_user_profile(db, user_id, "Reza")
+        updated = await update_user_profile(db, user_id, {"display_name": "Reza"})
         await db.commit()
         assert updated.display_name == "Reza"
 


### PR DESCRIPTION
## Summary
- `users.monthly_extra_credit_cap` (nullable Float, NULL = unlimited): per-user monthly USD cap on extra-credit overflow spend once entitlement windows are exhausted
- Gate-only enforcement: whitelist (`get_admin_all_api_keys`) and `get_allowance_state` treat prepaid as `min(balance, max(0, cap - month_overflow))`; cap reached + windows exhausted → keys withheld → 401, same as zero balance. Billing path untouched
- Month overflow = `SUM(credits_used - tier_credits_used)` over chargeable keys, calendar month, naive server time (same boundary as per-key `monthly_limit`); shared anonymous chat key excluded; aggregate skipped for uncapped users on the per-call path
- `PATCH /auth/me` now field-aware (partial update — also fixes latent `display_name` clobber) and accepts `monthly_extra_credit_cap` (finite, > 0; explicit null clears)
- `GET /payments/subscription` exposes `monthly_extra_credit_cap` + `extra_credits_used_this_month`; `allowed`/`source` are cap-aware so paywalls stay consistent with the gateway

Frontend: shared `UsageCreditsCard` gained the cap row + edit dialog (libertai-web-shared 55ccb86, already on main; console/chat submodules bumped).

## Note for feat/teams-v1 merge
The overflow sum attributes calls via `api_key.user_id`. The teams branch charges some calls to a different account — when merging, re-derive attribution from the chargeable user (teams get the same cap behavior, set by the team admin).

## Testing
- 296 backend tests (18 new: month bounds, effective prepaid, overflow aggregation incl. shared-key exclusion, whitelist gating, PATCH partial-update/validation incl. NaN/inf, response plumbing), ruff + mypy clean
- E2E through the real service stack: prepaid allowed → $1 cap set → $3 overflow → blocked + key withheld (raw balance intact) → cap cleared → allowed again