### PR TITLE
feat: classify blocked API keys with reasons in admin list

### DIFF
--- a/src/interfaces/api_keys.py
+++ b/src/interfaces/api_keys.py
@@ -15,6 +15,29 @@ class ApiKeyType(str, Enum):
     pool = "pool"
 
 
+class InvalidKeyReason(str, Enum):
+    """Why a real, non-deleted key is currently unusable (distributed with the whitelist)."""
+
+    disabled = "disabled"
+    expired = "expired"
+    key_monthly_limit = "key_monthly_limit"
+    no_credits = "no_credits"
+    extra_credit_cap = "extra_credit_cap"
+    liberclaw_limit = "liberclaw_limit"
+
+
+# Static strings on purpose: the map is re-distributed every refresh cycle,
+# dynamic content (timestamps) would churn the payload.
+INVALID_KEY_MESSAGES: dict[InvalidKeyReason, str] = {
+    InvalidKeyReason.disabled: "This API key has been disabled.",
+    InvalidKeyReason.expired: "This API key has expired.",
+    InvalidKeyReason.key_monthly_limit: "This API key reached its monthly usage limit.",
+    InvalidKeyReason.no_credits: "Usage window limit reached and no extra credits available.",
+    InvalidKeyReason.extra_credit_cap: "Monthly extra-credits cap reached.",
+    InvalidKeyReason.liberclaw_limit: "Usage limit for your plan reached.",
+}
+
+
 class InferenceKeyType(str, Enum):
     """Key types whose usage is recorded in ``inference_calls`` (everything but chat).
 
@@ -32,6 +55,15 @@ class InferenceCallType(str, Enum):
     text = "text"
     image = "image"
     audio = "audio"
+
+
+class InvalidKeyInfo(BaseModel):
+    reason: InvalidKeyReason
+    message: str
+
+
+def invalid_key_info(reason: InvalidKeyReason) -> InvalidKeyInfo:
+    return InvalidKeyInfo(reason=reason, message=INVALID_KEY_MESSAGES[reason])
 
 
 class ApiKeyCreate(BaseModel):
@@ -113,6 +145,7 @@ class ApiKeyListResponse(BaseModel):
 
 class ApiKeyAdminListResponse(BaseModel):
     keys: list[str]
+    invalid_keys: dict[str, InvalidKeyInfo] = {}
 
 
 class ChatApiKeyResponse(BaseModel):

--- a/src/routes/api_keys/api_keys.py
+++ b/src/routes/api_keys/api_keys.py
@@ -350,8 +350,8 @@ async def register_inference_call(usage_log: InferenceCallData) -> None:
 @router.get("/admin/list", dependencies=[Depends(verify_admin_token)])  # type: ignore
 async def get_admin_all_api_keys() -> ApiKeyAdminListResponse:
     try:
-        api_keys = await ApiKeyService.get_admin_all_api_keys()
-        return ApiKeyAdminListResponse(keys=api_keys)
+        result = await ApiKeyService.get_admin_all_api_keys()
+        return ApiKeyAdminListResponse(keys=result.valid, invalid_keys=result.invalid)
     except Exception as e:
         logger.error(f"Error getting all API keys: {str(e)}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -1,6 +1,7 @@
 import uuid
 
 from datetime import datetime, timedelta
+from typing import NamedTuple
 
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -8,7 +9,7 @@ from sqlalchemy.sql import func as sql_func
 
 from src.config import config
 from src.liberclaw_tiers import LIBERCLAW_TIERS
-from src.interfaces.api_keys import ApiKey, FullApiKey, ApiKeyType
+from src.interfaces.api_keys import ApiKey, FullApiKey, ApiKeyType, InvalidKeyInfo, InvalidKeyReason, invalid_key_info
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.inference_call import InferenceCall
@@ -17,6 +18,7 @@ from src.services.api_key_pool import ApiKeyPoolService
 from src.services.credit import CreditService
 from src.services.entitlement import (
     CHARGEABLE_KEY_TYPES,
+    PREPAID_MIN,
     WINDOW_5H,
     WINDOW_WEEKLY,
     active_tiers_by_users,
@@ -35,6 +37,11 @@ logger = setup_logger(__name__)
 
 # CLI API keys expire and must be re-minted via `libertai login`.
 CLI_KEY_TTL_DAYS = 90
+
+
+class AdminApiKeys(NamedTuple):
+    valid: list[str]
+    invalid: dict[str, InvalidKeyInfo]
 
 
 class ApiKeyService:
@@ -503,13 +510,14 @@ class ApiKeyService:
             raise
 
     @staticmethod
-    async def get_admin_all_api_keys() -> list[str]:
-        """
-        Get all API keys across all addresses that have at least 0.02 credits available.
-        This method is intended for admin use only.
+    async def get_admin_all_api_keys() -> AdminApiKeys:
+        """All non-deleted API keys, split into a usable whitelist and an
+        invalid map (key -> reason + message) for the gateway to surface.
 
-        Returns:
-            List of API key strings (unmasked) that meet the requirements
+        Never in the invalid map: deleted keys, ownership-broken keys, x402
+        keys, the shared chat service key, keys expired >30 days (map must
+        not grow unboundedly; disabled keys are kept — rare manual action,
+        no deactivation timestamp to prune on).
         """
 
         try:
@@ -518,7 +526,7 @@ class ApiKeyService:
                     (
                         await db.execute(
                             select(ApiKeyDB)
-                            .where(ApiKeyDB.is_active, ApiKeyDB.deleted_at.is_(None))
+                            .where(ApiKeyDB.deleted_at.is_(None))
                             .options(selectinload(ApiKeyDB.liberclaw_user))
                         )
                     )
@@ -532,8 +540,43 @@ class ApiKeyService:
                 # chat keys are created with monthly_limit=None.)
                 chargeable_api_types = CHARGEABLE_KEY_TYPES
 
+                valid: list[str] = []
+                invalid: dict[str, InvalidKeyInfo] = {}
+                now = datetime.now()
+                expired_keep_cutoff = now - timedelta(days=30)
+
+                # First pass: everything decidable without usage aggregates. Survivors
+                # (candidates) are the only keys whose users feed the batch pre-fetches.
+                candidates: list[ApiKeyDB] = []
+                for key in api_keys:
+                    if config.LIBERTAI_CHAT_API_KEY and key.key == config.LIBERTAI_CHAT_API_KEY:
+                        # Shared anonymous chat service key: always allowed, never gated.
+                        valid.append(key.key)
+                        continue
+                    if key.type == ApiKeyType.x402:
+                        # x402 requests carry their own payment auth; the key is internal
+                        # and must never surface user-facing reasons.
+                        if key.expires_at is not None and key.expires_at < now:
+                            continue
+                        if key.is_active:
+                            valid.append(key.key)
+                        continue
+                    # Ownership-broken keys are unusable but not user-explainable -> generic 401.
+                    if key.type == ApiKeyType.liberclaw and (key.liberclaw_user_id is None or key.liberclaw_user is None):
+                        continue
+                    if key.type in chargeable_api_types and not key.user_id:
+                        continue
+                    if not key.is_active:
+                        invalid[key.key] = invalid_key_info(InvalidKeyReason.disabled)
+                        continue
+                    if key.expires_at is not None and key.expires_at < now:
+                        if key.expires_at >= expired_keep_cutoff:
+                            invalid[key.key] = invalid_key_info(InvalidKeyReason.expired)
+                        continue
+                    candidates.append(key)
+
                 # Pre-fetch balances for all users to avoid N+1 queries
-                user_ids = {k.user_id for k in api_keys if k.user_id and k.type in chargeable_api_types}
+                user_ids = {k.user_id for k in candidates if k.user_id and k.type in chargeable_api_types}
                 balances: dict[uuid.UUID, float] = {}
                 if user_ids:
                     from src.models.credit_transaction import CreditTransaction
@@ -557,7 +600,6 @@ class ApiKeyService:
 
                 # Pre-fetch dual fixed-window entitlement inputs (usage within each user's
                 # active 5h + weekly window, active tier) so the per-key loop is pure computation.
-                now = datetime.now()
                 window_5h_usage = await window_usage_by_users(db, user_ids, WINDOW_5H, now)
                 weekly_usage = await window_usage_by_users(db, user_ids, WINDOW_WEEKLY, now)
                 active_tiers = await active_tiers_by_users(db, user_ids)
@@ -578,7 +620,7 @@ class ApiKeyService:
 
                 # Pre-fetch current month usage for API keys with monthly limits
                 api_keys_with_limits = [
-                    k for k in api_keys if k.type in chargeable_api_types and k.monthly_limit is not None
+                    k for k in candidates if k.type in chargeable_api_types and k.monthly_limit is not None
                 ]
                 monthly_usage: dict[uuid.UUID, float] = {}
                 if api_keys_with_limits:
@@ -604,9 +646,7 @@ class ApiKeyService:
                 # Pre-fetch liberclaw rolling-window usage, grouped per distinct window, to avoid
                 # an N+1 SUM over inference_calls for every liberclaw key.
                 liberclaw_keys = [
-                    k
-                    for k in api_keys
-                    if k.type == ApiKeyType.liberclaw and k.liberclaw_user_id and k.liberclaw_user
+                    k for k in candidates if k.type == ApiKeyType.liberclaw and k.liberclaw_user_id and k.liberclaw_user
                 ]
                 liberclaw_usage: dict[uuid.UUID, float] = {}
                 if liberclaw_keys:
@@ -636,56 +676,50 @@ class ApiKeyService:
                         for row in rows:
                             liberclaw_usage[row[0]] = float(row[1])
 
-                # Filter keys with sufficient credits available
-                expiry_now = datetime.now()
-                result = []
-                for key in api_keys:
-                    # Expired keys (CLI keys past their TTL) drop off the whitelist -> 401 at the gateway.
-                    if key.expires_at is not None and key.expires_at < expiry_now:
-                        continue
+                # Second pass: limit checks over pre-fetched aggregates.
+                for key in candidates:
                     if key.type == ApiKeyType.liberclaw:
-                        # Rolling-window usage vs tier limit (usage pre-fetched above).
-                        if key.liberclaw_user_id is None:
-                            continue
+                        # First pass already dropped liberclaw keys with no liberclaw_user.
                         lc_user = key.liberclaw_user
                         if lc_user is None:
                             continue
                         tier_config = LIBERCLAW_TIERS.get(lc_user.tier, LIBERCLAW_TIERS["free"])
-                        usage = liberclaw_usage.get(key.id, 0.0)
-                        if usage >= tier_config["credits_limit"]:
+                        if liberclaw_usage.get(key.id, 0.0) >= tier_config["credits_limit"]:
+                            invalid[key.key] = invalid_key_info(InvalidKeyReason.liberclaw_limit)
                             continue
                     elif key.type in chargeable_api_types:
-                        if config.LIBERTAI_CHAT_API_KEY and key.key == config.LIBERTAI_CHAT_API_KEY:
-                            # Shared anonymous chat service key: always allowed, never gated.
-                            result.append(key.key)
-                            continue
-                        if not key.user_id:
+                        # First pass already dropped chargeable keys with no owner.
+                        user_id = key.user_id
+                        if user_id is None:
                             continue
                         # Per-key monthly limit is an extra cap (if the user set one).
-                        if key.monthly_limit is not None:
-                            key_usage = monthly_usage.get(key.id, 0.0)
-                            if key_usage >= key.monthly_limit:
-                                continue
+                        if key.monthly_limit is not None and monthly_usage.get(key.id, 0.0) >= key.monthly_limit:
+                            invalid[key.key] = invalid_key_info(InvalidKeyReason.key_monthly_limit)
+                            continue
                         # Dual-window entitlement: free tier (or larger paid windows) by
                         # default, prepaid balance as the overflow path.
-                        tier = get_tier(active_tiers.get(key.user_id, DEFAULT_TIER))
+                        tier = get_tier(active_tiers.get(user_id, DEFAULT_TIER))
+                        prepaid = balances.get(user_id, 0.0)
                         source = compute_source(
                             tier,
-                            window_5h_usage.get(key.user_id, 0.0),
-                            weekly_usage.get(key.user_id, 0.0),
-                            effective_prepaid(
-                                balances.get(key.user_id, 0.0),
-                                caps.get(key.user_id),
-                                cap_overflow.get(key.user_id, 0.0),
-                            ),
+                            window_5h_usage.get(user_id, 0.0),
+                            weekly_usage.get(user_id, 0.0),
+                            effective_prepaid(prepaid, caps.get(user_id), cap_overflow.get(user_id, 0.0)),
                         )
                         if source == "blocked":
+                            # Cap-blocked vs genuinely broke: raw prepaid distinguishes them.
+                            reason = (
+                                InvalidKeyReason.extra_credit_cap
+                                if prepaid >= PREPAID_MIN
+                                else InvalidKeyReason.no_credits
+                            )
+                            invalid[key.key] = invalid_key_info(reason)
                             continue
 
-                    # valid liberclaw/api/cli/chat keys pass through
-                    result.append(key.key)
+                    # valid liberclaw/api/cli/chat/pool keys pass through
+                    valid.append(key.key)
 
-                return result
+                return AdminApiKeys(valid=valid, invalid=invalid)
 
         except Exception as e:
             logger.error(f"Error getting all API keys: {str(e)}", exc_info=True)

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -561,6 +561,13 @@ class ApiKeyService:
                         if key.is_active:
                             valid.append(key.key)
                         continue
+                    if key.type == ApiKeyType.pool:
+                        # Unclaimed pool keys are internal (no owner, never sent by users):
+                        # usable ones ride the whitelist so they're warm when claimed,
+                        # dead ones get no user-facing reason.
+                        if key.is_active and not (key.expires_at is not None and key.expires_at < now):
+                            valid.append(key.key)
+                        continue
                     # Ownership-broken keys are unusable but not user-explainable -> generic 401.
                     if key.type == ApiKeyType.liberclaw and (key.liberclaw_user_id is None or key.liberclaw_user is None):
                         continue
@@ -650,7 +657,6 @@ class ApiKeyService:
                 ]
                 liberclaw_usage: dict[uuid.UUID, float] = {}
                 if liberclaw_keys:
-                    now = datetime.now()
                     key_ids_by_window: dict[int, list[uuid.UUID]] = {}
                     for k in liberclaw_keys:
                         lc_user = k.liberclaw_user

--- a/tests/test_admin_list_enforcement.py
+++ b/tests/test_admin_list_enforcement.py
@@ -26,6 +26,10 @@ from src.services.entitlement import WINDOW_5H
 pytestmark = pytest.mark.asyncio
 
 
+async def _valid_keys() -> list[str]:
+    return (await ApiKeyService.get_admin_all_api_keys()).valid
+
+
 async def _setup(*, usage=None, window="active", prepaid=0.0, tier=None, cap=None, overflow=0.0):
     """Create a user + api key with optional usage in an active/expired 5h window.
 
@@ -86,7 +90,7 @@ async def _cleanup(user_id):
 async def test_free_key_included_within_window():
     user_id, key = await _setup()
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -94,7 +98,7 @@ async def test_free_key_included_within_window():
 async def test_free_key_excluded_when_window_exhausted_no_prepaid():
     user_id, key = await _setup(usage=0.5, window="active")  # free 5h limit is 0.5
     try:
-        assert key not in await ApiKeyService.get_admin_all_api_keys()
+        assert key not in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -102,7 +106,7 @@ async def test_free_key_excluded_when_window_exhausted_no_prepaid():
 async def test_key_returns_after_window_resets():
     user_id, key = await _setup(usage=0.5, window="expired")  # window ended -> usage reset to 0
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -110,7 +114,7 @@ async def test_key_returns_after_window_resets():
 async def test_paid_tier_gets_larger_window():
     user_id, key = await _setup(usage=0.5, window="active", tier="plus")  # exhausts free, fine for plus
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -118,7 +122,7 @@ async def test_paid_tier_gets_larger_window():
 async def test_prepaid_overflow_keeps_key_included():
     user_id, key = await _setup(usage=0.5, window="active", prepaid=5.0)
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -150,7 +154,7 @@ async def test_pool_keys_are_included_in_whitelist_unconditionally():
         db.add(row)
         await db.commit()
     try:
-        assert pool_key in await ApiKeyService.get_admin_all_api_keys()
+        assert pool_key in await _valid_keys()
     finally:
         async with AsyncSessionLocal() as db:
             from sqlalchemy import delete
@@ -196,7 +200,7 @@ async def test_liberclaw_key_included_within_tier_limit():
     limit = LIBERCLAW_TIERS["free"]["credits_limit"]
     lc_id, key = await _setup_liberclaw(usage=limit / 2)  # half the rolling-window allowance
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup_liberclaw(lc_id)
 
@@ -205,7 +209,7 @@ async def test_liberclaw_key_excluded_over_tier_limit():
     limit = LIBERCLAW_TIERS["free"]["credits_limit"]
     lc_id, key = await _setup_liberclaw(usage=limit + 1)  # exhausted the rolling window
     try:
-        assert key not in await ApiKeyService.get_admin_all_api_keys()
+        assert key not in await _valid_keys()
     finally:
         await _cleanup_liberclaw(lc_id)
 
@@ -215,7 +219,7 @@ async def test_liberclaw_usage_outside_window_ignored():
     free = LIBERCLAW_TIERS["free"]
     lc_id, key = await _setup_liberclaw(usage=free["credits_limit"] + 1, used_days_ago=free["rolling_window_days"] + 5)
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup_liberclaw(lc_id)
 
@@ -224,7 +228,7 @@ async def test_cap_reached_excludes_key_when_window_exhausted():
     # Free 5h window exhausted; prepaid exists but this month's overflow >= cap.
     user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=2.0, overflow=3.0)
     try:
-        assert key not in await ApiKeyService.get_admin_all_api_keys()
+        assert key not in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -232,7 +236,7 @@ async def test_cap_reached_excludes_key_when_window_exhausted():
 async def test_cap_not_reached_keeps_key():
     user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=10.0, overflow=3.0)
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -241,7 +245,7 @@ async def test_cap_reached_but_window_open_keeps_key():
     # Windows have room -> "tier" source; the cap only governs the prepaid path.
     user_id, key = await _setup(usage=0.1, window="active", prepaid=50.0, cap=2.0, overflow=3.0)
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -249,7 +253,7 @@ async def test_cap_reached_but_window_open_keeps_key():
 async def test_no_cap_unlimited_overflow_keeps_key():
     user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=None, overflow=999.0)
     try:
-        assert key in await ApiKeyService.get_admin_all_api_keys()
+        assert key in await _valid_keys()
     finally:
         await _cleanup(user_id)
 
@@ -258,7 +262,7 @@ async def test_balance_still_binds_below_cap():
     # Cap has room but prepaid < PREPAID_MIN -> still blocked.
     user_id, key = await _setup(usage=0.5, window="active", prepaid=0.01, cap=100.0, overflow=1.0)
     try:
-        assert key not in await ApiKeyService.get_admin_all_api_keys()
+        assert key not in await _valid_keys()
     finally:
         await _cleanup(user_id)
 

--- a/tests/test_admin_list_invalid_reasons.py
+++ b/tests/test_admin_list_invalid_reasons.py
@@ -124,3 +124,19 @@ async def test_valid_key_not_in_invalid_map():
         assert key not in res.invalid
     finally:
         await _cleanup(user_id)
+
+
+async def test_admin_route_serializes_invalid_map():
+    from src.interfaces.api_keys import ApiKeyAdminListResponse
+
+    user_id, key = await _setup()
+    await _mutate_key(key, is_active=False)
+    try:
+        res = await _admin()
+        payload = ApiKeyAdminListResponse(keys=res.valid, invalid_keys=res.invalid).model_dump()
+        assert payload["invalid_keys"][key] == {
+            "reason": "disabled",
+            "message": "This API key has been disabled.",
+        }
+    finally:
+        await _cleanup(user_id)

--- a/tests/test_admin_list_invalid_reasons.py
+++ b/tests/test_admin_list_invalid_reasons.py
@@ -7,11 +7,12 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from src.interfaces.api_keys import InvalidKeyReason
+from src.interfaces.api_keys import ApiKeyType, InvalidKeyReason
 from src.liberclaw_tiers import LIBERCLAW_TIERS
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.services.api_key import ApiKeyService
+from src.services.api_key_pool import POOL_SENTINEL_NAME
 from tests.test_admin_list_enforcement import _cleanup, _cleanup_liberclaw, _setup, _setup_liberclaw
 
 pytestmark = pytest.mark.asyncio
@@ -140,3 +141,72 @@ async def test_admin_route_serializes_invalid_map():
         }
     finally:
         await _cleanup(user_id)
+
+
+async def _delete_key(key_str):
+    from sqlalchemy import delete
+
+    async with AsyncSessionLocal() as db:
+        await db.execute(delete(ApiKeyDB).where(ApiKeyDB.key == key_str))
+        await db.commit()
+
+
+async def test_ownerless_liberclaw_key_in_neither_list():
+    # liberclaw_user_id=None: ownership-broken, not user-explainable -> generic 401, not surfaced.
+    key_str = ApiKeyDB.generate_key()
+    async with AsyncSessionLocal() as db:
+        db.add(ApiKeyDB(key=key_str, name="ownerless-liberclaw", type=ApiKeyType.liberclaw, liberclaw_user_id=None))
+        await db.commit()
+    try:
+        res = await _admin()
+        assert key_str not in res.valid
+        assert key_str not in res.invalid
+    finally:
+        await _delete_key(key_str)
+
+
+async def test_ownerless_api_key_in_neither_list():
+    # user_id=None: ownership-broken, not user-explainable -> generic 401, not surfaced.
+    key_str = ApiKeyDB.generate_key()
+    async with AsyncSessionLocal() as db:
+        db.add(ApiKeyDB(key=key_str, name="ownerless-api", type=ApiKeyType.api, user_id=None))
+        await db.commit()
+    try:
+        res = await _admin()
+        assert key_str not in res.valid
+        assert key_str not in res.invalid
+    finally:
+        await _delete_key(key_str)
+
+
+async def test_disabled_x402_key_in_neither_list():
+    # x402 keys are internal (own payment auth) -> never surfaced with a user-facing reason.
+    key_str = ApiKeyDB.generate_key()
+    async with AsyncSessionLocal() as db:
+        row = ApiKeyDB(key=key_str, name="disabled-x402", type=ApiKeyType.x402)
+        row.is_active = False
+        db.add(row)
+        await db.commit()
+    try:
+        res = await _admin()
+        assert key_str not in res.valid
+        assert key_str not in res.invalid
+    finally:
+        await _delete_key(key_str)
+
+
+async def test_disabled_pool_key_reported_invalid():
+    # Pool keys aren't ownership- or x402-exempt, so a disabled one is reported like any
+    # other disabled key (reason=disabled) rather than silently dropped.
+    key_str = ApiKeyDB.generate_key()
+    async with AsyncSessionLocal() as db:
+        row = ApiKeyDB(key=key_str, name=POOL_SENTINEL_NAME, type=ApiKeyType.pool)
+        row.is_active = False
+        db.add(row)
+        await db.commit()
+    try:
+        res = await _admin()
+        assert key_str not in res.valid
+        assert res.invalid[key_str].reason == InvalidKeyReason.disabled
+    finally:
+        await _delete_key(key_str)

--- a/tests/test_admin_list_invalid_reasons.py
+++ b/tests/test_admin_list_invalid_reasons.py
@@ -195,9 +195,9 @@ async def test_disabled_x402_key_in_neither_list():
         await _delete_key(key_str)
 
 
-async def test_disabled_pool_key_reported_invalid():
-    # Pool keys aren't ownership- or x402-exempt, so a disabled one is reported like any
-    # other disabled key (reason=disabled) rather than silently dropped.
+async def test_disabled_pool_key_in_neither_list():
+    # Pool keys are internal (no owner, never sent by users) -> a disabled one is
+    # silently dropped, never surfaced with a user-facing reason.
     key_str = ApiKeyDB.generate_key()
     async with AsyncSessionLocal() as db:
         row = ApiKeyDB(key=key_str, name=POOL_SENTINEL_NAME, type=ApiKeyType.pool)
@@ -207,6 +207,35 @@ async def test_disabled_pool_key_reported_invalid():
     try:
         res = await _admin()
         assert key_str not in res.valid
-        assert res.invalid[key_str].reason == InvalidKeyReason.disabled
+        assert key_str not in res.invalid
     finally:
         await _delete_key(key_str)
+
+
+async def test_expired_x402_key_in_neither_list():
+    # Expired x402 keys are silently dropped, same as disabled ones.
+    key_str = ApiKeyDB.generate_key()
+    async with AsyncSessionLocal() as db:
+        row = ApiKeyDB(key=key_str, name="expired-x402", type=ApiKeyType.x402)
+        row.expires_at = datetime.now() - timedelta(days=1)
+        db.add(row)
+        await db.commit()
+    try:
+        res = await _admin()
+        assert key_str not in res.valid
+        assert key_str not in res.invalid
+    finally:
+        await _delete_key(key_str)
+
+
+async def test_key_expired_just_under_30_days_still_reported():
+    # Pins the pruning window from the inside (31d prune case is covered above);
+    # the exact 30d edge isn't testable deterministically against wall-clock now().
+    user_id, key = await _setup()
+    await _mutate_key(key, expires_at=datetime.now() - timedelta(days=29, hours=23))
+    try:
+        res = await _admin()
+        assert key not in res.valid
+        assert res.invalid[key].reason == InvalidKeyReason.expired
+    finally:
+        await _cleanup(user_id)

--- a/tests/test_admin_list_invalid_reasons.py
+++ b/tests/test_admin_list_invalid_reasons.py
@@ -1,0 +1,126 @@
+"""Invalid-key classification in the admin list (reason map distributed to the gateway).
+
+Service opens its own session with real datetime.now(); each test cleans its rows.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.interfaces.api_keys import InvalidKeyReason
+from src.liberclaw_tiers import LIBERCLAW_TIERS
+from src.models.api_key import ApiKey as ApiKeyDB
+from src.models.base import AsyncSessionLocal
+from src.services.api_key import ApiKeyService
+from tests.test_admin_list_enforcement import _cleanup, _cleanup_liberclaw, _setup, _setup_liberclaw
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _mutate_key(key_str, **attrs):
+    from sqlalchemy import select
+
+    async with AsyncSessionLocal() as db:
+        row = (await db.execute(select(ApiKeyDB).where(ApiKeyDB.key == key_str))).scalars().one()
+        for name, value in attrs.items():
+            setattr(row, name, value)
+        await db.commit()
+
+
+async def _admin():
+    return await ApiKeyService.get_admin_all_api_keys()
+
+
+async def test_disabled_key_reported():
+    user_id, key = await _setup()
+    await _mutate_key(key, is_active=False)
+    try:
+        res = await _admin()
+        assert key not in res.valid
+        assert res.invalid[key].reason == InvalidKeyReason.disabled
+        assert res.invalid[key].message
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_recently_expired_key_reported():
+    user_id, key = await _setup()
+    await _mutate_key(key, expires_at=datetime.now() - timedelta(days=1))
+    try:
+        res = await _admin()
+        assert key not in res.valid
+        assert res.invalid[key].reason == InvalidKeyReason.expired
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_long_expired_key_pruned_from_both_lists():
+    user_id, key = await _setup()
+    await _mutate_key(key, expires_at=datetime.now() - timedelta(days=31))
+    try:
+        res = await _admin()
+        assert key not in res.valid
+        assert key not in res.invalid
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_deleted_key_in_neither_list():
+    user_id, key = await _setup()
+    await _mutate_key(key, is_active=False, deleted_at=datetime.now())
+    try:
+        res = await _admin()
+        assert key not in res.valid
+        assert key not in res.invalid
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_no_credits_reason():
+    # Free 5h window exhausted (limit 0.5), no prepaid.
+    user_id, key = await _setup(usage=0.5, window="active")
+    try:
+        res = await _admin()
+        assert res.invalid[key].reason == InvalidKeyReason.no_credits
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_extra_credit_cap_reason():
+    # Window exhausted; prepaid exists but monthly cap consumed by overflow.
+    user_id, key = await _setup(usage=0.5, window="active", prepaid=50.0, cap=2.0, overflow=3.0)
+    try:
+        res = await _admin()
+        assert res.invalid[key].reason == InvalidKeyReason.extra_credit_cap
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_key_monthly_limit_reason():
+    user_id, key = await _setup()
+    await _mutate_key(key, monthly_limit=0.0)
+    try:
+        res = await _admin()
+        assert res.invalid[key].reason == InvalidKeyReason.key_monthly_limit
+    finally:
+        await _cleanup(user_id)
+
+
+async def test_liberclaw_limit_reason():
+    limit = LIBERCLAW_TIERS["free"]["credits_limit"]
+    lc_id, key = await _setup_liberclaw(usage=limit + 1)
+    try:
+        res = await _admin()
+        assert res.invalid[key].reason == InvalidKeyReason.liberclaw_limit
+    finally:
+        await _cleanup_liberclaw(lc_id)
+
+
+async def test_valid_key_not_in_invalid_map():
+    user_id, key = await _setup()
+    try:
+        res = await _admin()
+        assert key in res.valid
+        assert key not in res.invalid
+    finally:
+        await _cleanup(user_id)

--- a/tests/test_api_key_soft_delete.py
+++ b/tests/test_api_key_soft_delete.py
@@ -71,7 +71,7 @@ async def test_soft_delete_hides_key_but_keeps_usage():
         # Excluded from the inference gateway.
         async with AsyncSessionLocal() as db:
             key_str = (await db.get(ApiKeyDB, key_id)).key
-        assert key_str not in await ApiKeyService.get_admin_all_api_keys()
+        assert key_str not in (await ApiKeyService.get_admin_all_api_keys()).valid
     finally:
         await _cleanup(user_id)
 

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -142,13 +142,13 @@ async def test_expired_cli_key_excluded_from_gateway(async_client):
     try:
         created = await ApiKeyService.rotate_or_create_cli_api_key(uid, host="box")
         # Live CLI key is on the gateway whitelist.
-        assert created.full_key in await ApiKeyService.get_admin_all_api_keys()
+        assert created.full_key in (await ApiKeyService.get_admin_all_api_keys()).valid
 
         # Force-expire it -> drops off the whitelist.
         async with AsyncSessionLocal() as db:
             row = await db.get(ApiKeyDB, created.id)
             row.expires_at = datetime.now() - timedelta(seconds=1)
             await db.commit()
-        assert created.full_key not in await ApiKeyService.get_admin_all_api_keys()
+        assert created.full_key not in (await ApiKeyService.get_admin_all_api_keys()).valid
     finally:
         await _cleanup(uid)

--- a/tests/test_inference_call_billing.py
+++ b/tests/test_inference_call_billing.py
@@ -183,11 +183,11 @@ async def test_chat_key_whitelisted_at_gateway_with_zero_balance():
 
     chat_key = await ApiKeyService.get_or_create_chat_api_key(user_id=user_id, user_address=address)
 
-    whitelist = await ApiKeyService.get_admin_all_api_keys()
+    whitelist = (await ApiKeyService.get_admin_all_api_keys()).valid
     assert chat_key.full_key in whitelist  # present: zero usage is within free tier window
 
     await ApiKeyService.delete_api_key(chat_key.id)
-    whitelist_after = await ApiKeyService.get_admin_all_api_keys()
+    whitelist_after = (await ApiKeyService.get_admin_all_api_keys()).valid
     assert chat_key.full_key not in whitelist_after  # soft-deleted keys drop off
 
 
@@ -219,7 +219,7 @@ async def test_blocked_chat_key_drops_from_whitelist():
     await ApiKeyService.register_inference_call(
         key=chat_key.full_key, credits_used=2.5, model_name="m"
     )
-    whitelist = await ApiKeyService.get_admin_all_api_keys()
+    whitelist = (await ApiKeyService.get_admin_all_api_keys()).valid
     assert chat_key.full_key not in whitelist
 
 
@@ -234,5 +234,5 @@ async def test_shared_free_chat_key_always_whitelisted(monkeypatch):
     # Even with usage that would block a normal user:
     await ApiKeyService.register_inference_call(key=chat_key.full_key, credits_used=5.0, model_name="m")
 
-    whitelist = await ApiKeyService.get_admin_all_api_keys()
+    whitelist = (await ApiKeyService.get_admin_all_api_keys()).valid
     assert chat_key.full_key in whitelist

--- a/tests/test_invalid_key_info.py
+++ b/tests/test_invalid_key_info.py
@@ -1,0 +1,19 @@
+from src.interfaces.api_keys import (
+    ApiKeyAdminListResponse,
+    InvalidKeyInfo,
+    InvalidKeyReason,
+    invalid_key_info,
+)
+
+
+def test_every_reason_has_a_message():
+    for reason in InvalidKeyReason:
+        info = invalid_key_info(reason)
+        assert isinstance(info, InvalidKeyInfo)
+        assert info.reason == reason
+        assert info.message  # non-empty human string
+
+
+def test_admin_list_response_defaults_to_empty_invalid_map():
+    resp = ApiKeyAdminListResponse(keys=["a"])
+    assert resp.invalid_keys == {}


### PR DESCRIPTION
Part 1/3 of invalid-key reasons (with libertai-api and libertai-models PRs).

Keys blocked by limits/credits are no longer silently dropped from `/api-keys/admin/list`: the response gains `invalid_keys: {key: {reason, message}}` so the gateway can return a specific 403 instead of a generic 401.

- Reasons: `disabled`, `expired` (≤30d, older pruned), `key_monthly_limit`, `no_credits`, `extra_credit_cap`, `liberclaw_limit`; messages authored here only.
- Never in the map: deleted, ownership-broken, x402-type, pool-type, chat service key.
- Two-pass classification; dead keys' users excluded from batch pre-fetches.
- Retro-compatible: `keys` field unchanged; deploy this first.

Tests: 335 passed.