### PR TITLE
Enforce one live CLI key per device

### DIFF
--- a/alembic/versions/a9c47e2b81f0_cli_key_unique_per_device.py
+++ b/alembic/versions/a9c47e2b81f0_cli_key_unique_per_device.py
@@ -1,0 +1,54 @@
+"""one live cli api key per (user, device name)
+
+Revision ID: a9c47e2b81f0
+Revises: d64e36784e9f
+Create Date: 2026-08-04
+
+Duplicate cli rows exist because rotate_or_create_cli_api_key did a SELECT-then-INSERT
+with nothing to serialise it. Retire the duplicates, then let the DB enforce the rule.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a9c47e2b81f0"
+down_revision: str | None = "d64e36784e9f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INDEX_NAME = "uq_api_keys_cli_user_name"
+
+# NULLS LAST is load-bearing: DESC alone is NULLS FIRST, which ranks a never-used row
+# above a used one and would retire the device that actually works.
+DEDUP = """
+WITH ranked AS (
+  SELECT k.id,
+         row_number() OVER (
+           PARTITION BY k.user_id, k.name
+           ORDER BY (SELECT max(ic.used_at) FROM inference_calls ic
+                     WHERE ic.api_key_id = k.id) DESC NULLS LAST,
+                    k.created_at DESC NULLS LAST
+         ) AS rn
+  FROM api_keys k
+  WHERE k.type = 'cli' AND k.deleted_at IS NULL AND k.user_id IS NOT NULL
+)
+UPDATE api_keys SET deleted_at = LOCALTIMESTAMP, is_active = false
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1)
+"""
+
+
+def upgrade() -> None:
+    # Both statements share one transaction, so no login can slip a duplicate in between.
+    # That rules out CONCURRENTLY, which cannot run inside a transaction and would leave an
+    # INVALID index enforcing nothing if the build failed.
+    op.execute(DEDUP)
+    op.execute(
+        f"CREATE UNIQUE INDEX {INDEX_NAME} ON api_keys (user_id, name) "
+        "WHERE type = 'cli' AND deleted_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {INDEX_NAME}")

--- a/src/models/api_key.py
+++ b/src/models/api_key.py
@@ -63,8 +63,9 @@ class ApiKey(Base):
     )
     liberclaw_user: Mapped["LiberclawUser | None"] = relationship("LiberclawUser", back_populates="api_keys")
 
-    # Names are not unique: a user may have several keys sharing a name (and reuse a
-    # soft-deleted key's name freely).
+    # Names are not unique in general: a user may have several keys sharing a name (and
+    # reuse a soft-deleted key's name freely). Live CLI keys are the exception — see the
+    # partial unique index in __table_args__.
 
     def __init__(
         self,

--- a/src/models/api_key.py
+++ b/src/models/api_key.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import TIMESTAMP, UUID, Boolean, Enum, Float, ForeignKey, String, func, select
+from sqlalchemy import TIMESTAMP, UUID, Boolean, Enum, Float, ForeignKey, Index, String, func, select, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql.expression import func as sql_func
 
@@ -19,6 +19,18 @@ if TYPE_CHECKING:
 
 class ApiKey(Base):
     __tablename__ = "api_keys"
+    __table_args__ = (
+        # One live CLI key per (user, device name). Scoped to cli — name uniqueness is
+        # deliberately absent for type=api. Soft-deleted rows fall outside the index, so a
+        # disconnect followed by `libertai login` mints a fresh row rather than colliding.
+        Index(
+            "uq_api_keys_cli_user_name",
+            "user_id",
+            "name",
+            unique=True,
+            postgresql_where=text("type = 'cli' AND deleted_at IS NULL"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
     key: Mapped[str] = mapped_column(String, unique=True, nullable=False, index=True)

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -2,7 +2,8 @@ import uuid
 from datetime import datetime, timedelta
 from typing import NamedTuple
 
-from sqlalchemy import select
+from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import func as sql_func
 
@@ -127,63 +128,45 @@ class ApiKeyService:
     ) -> FullApiKey:
         """Mint — or rotate in place — the CLI API key for a user/device.
 
-        Keyed on (user_id, name, type=cli) so the row, and its related inference_calls
-        (usage history), survives re-login: only the secret key value and expiry are
-        regenerated. Used as the final step of the CLI browser-SSO login flow.
+        Upserted on (user_id, name) so the row, and its related inference_calls (usage
+        history), survives re-login: only the secret and the expiry are regenerated. Used
+        as the final step of the CLI browser-SSO login flow.
         """
         name = f"libertai-cli@{host}" if host else "libertai-cli"
         expires_at = datetime.now() + timedelta(days=CLI_KEY_TTL_DAYS)
 
         try:
             async with AsyncSessionLocal() as db:
-                existing = (
-                    (
-                        await db.execute(
-                            select(ApiKeyDB).where(
-                                ApiKeyDB.user_id == user_id,
-                                ApiKeyDB.name == name,
-                                ApiKeyDB.type == ApiKeyType.cli,
-                                ApiKeyDB.deleted_at.is_(None),
-                            )
-                        )
-                    )
-                    .scalars()
-                    .first()
-                )
+                # Adopt a warm string if one is ready. It is consumed on both branches — the
+                # insert uses it directly, and DO UPDATE sets key to the same value — so the
+                # refill is scheduled exactly when a pooled string was actually taken.
+                warm = await ApiKeyPoolService.claim_warm_string(db)
+                claimed = warm is not None
+                new_key = warm if warm is not None else ApiKeyDB.generate_key()
 
-                claimed = False
-                if existing is not None:
-                    # Rotate in place: same row (and usage history), new secret + expiry.
-                    # Adopt a warm string if one is ready; the pool row is deleted first
-                    # (inside claim_warm_string) so UNIQUE(key) is never violated.
-                    warm = await ApiKeyPoolService.claim_warm_string(db)
-                    existing.key = warm if warm is not None else ApiKeyDB.generate_key()
-                    existing.expires_at = expires_at
-                    existing.is_active = True
-                    api_key = existing
-                    claimed = warm is not None
-                else:
-                    pool_row = await ApiKeyPoolService.claim_warm_key(
-                        db,
-                        target_type=ApiKeyType.cli,
-                        user_id=user_id,
+                stmt = (
+                    pg_insert(ApiKeyDB)
+                    .values(
+                        key=new_key,
                         name=name,
+                        user_id=user_id,
                         user_address=user_address,
+                        type=ApiKeyType.cli,
                         expires_at=expires_at,
                     )
-                    if pool_row is not None:
-                        api_key = pool_row
-                        claimed = True
-                    else:
-                        api_key = ApiKeyDB(
-                            key=ApiKeyDB.generate_key(),
-                            name=name,
-                            user_id=user_id,
-                            user_address=user_address,
-                            type=ApiKeyType.cli,
-                            expires_at=expires_at,
-                        )
-                        db.add(api_key)
+                    .on_conflict_do_update(
+                        index_elements=[ApiKeyDB.user_id, ApiKeyDB.name],
+                        # Must be a literal. The ORM form (ApiKeyDB.type == ApiKeyType.cli)
+                        # renders as a bind parameter, and Postgres can only prove a partial
+                        # index implication against Const nodes: it works on a custom plan and
+                        # then raises InvalidColumnReference once the plan cache goes generic.
+                        index_where=text("type = 'cli' AND deleted_at IS NULL"),
+                        set_={"key": new_key, "expires_at": expires_at, "is_active": True},
+                    )
+                )
+                api_key = (
+                    (await db.execute(select(ApiKeyDB).from_statement(stmt.returning(ApiKeyDB)))).scalars().one()
+                )
                 key = api_key.key
                 await db.commit()
 

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -702,9 +702,7 @@ class ApiKeyService:
                         if lc_user is None:
                             continue
                         tier_config = LIBERCLAW_TIERS.get(lc_user.tier, LIBERCLAW_TIERS["free"])
-                        effective_limit = tier_config["credits_limit"] + liberclaw_extra.get(
-                            key.liberclaw_user_id, 0.0
-                        )
+                        effective_limit = tier_config["credits_limit"] + liberclaw_extra.get(lc_user.id, 0.0)
                         if liberclaw_usage.get(key.id, 0.0) >= effective_limit:
                             invalid[key.key] = invalid_key_info(InvalidKeyReason.liberclaw_limit)
                             continue

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import pytest
 from cryptography.fernet import Fernet
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 
 from src.config import config
 from src.interfaces.api_keys import ApiKeyType
@@ -152,3 +153,28 @@ async def test_expired_cli_key_excluded_from_gateway(async_client):
         assert created.full_key not in (await ApiKeyService.get_admin_all_api_keys()).valid
     finally:
         await _cleanup(uid)
+
+
+async def test_duplicate_live_cli_name_rejected():
+    async with AsyncSessionLocal() as db:
+        user, _ = await get_or_create_user_by_email(db, f"cli-{uuid.uuid4().hex}@example.com")
+        await db.commit()
+    try:
+        async with AsyncSessionLocal() as db:
+            db.add(
+                ApiKeyDB(
+                    key=ApiKeyDB.generate_key(), name="libertai-cli@dup", user_id=user.id, type=ApiKeyType.cli
+                )
+            )
+            await db.commit()
+
+        with pytest.raises(IntegrityError):
+            async with AsyncSessionLocal() as db:
+                db.add(
+                    ApiKeyDB(
+                        key=ApiKeyDB.generate_key(), name="libertai-cli@dup", user_id=user.id, type=ApiKeyType.cli
+                    )
+                )
+                await db.commit()
+    finally:
+        await _cleanup(user.id)

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from cryptography.fernet import Fernet
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
 from src.config import config
@@ -176,5 +176,48 @@ async def test_duplicate_live_cli_name_rejected():
                     )
                 )
                 await db.commit()
+    finally:
+        await _cleanup(user.id)
+
+
+async def test_cli_key_reminted_after_disconnect():
+    async with AsyncSessionLocal() as db:
+        user, _ = await get_or_create_user_by_email(db, f"cli-{uuid.uuid4().hex}@example.com")
+        await db.commit()
+    try:
+        first = await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="box")
+        await ApiKeyService.delete_api_key(first.id)
+
+        second = await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="box")
+
+        assert second.id != first.id  # soft-deleted row is outside the index, so a new row
+        async with AsyncSessionLocal() as db:
+            live = (
+                (
+                    await db.execute(
+                        select(ApiKeyDB).where(
+                            ApiKeyDB.user_id == user.id,
+                            ApiKeyDB.name == "libertai-cli@box",
+                            ApiKeyDB.deleted_at.is_(None),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(live) == 1
+    finally:
+        await _cleanup(user.id)
+
+
+async def test_cli_key_rotation_survives_repeated_calls():
+    """The ON CONFLICT arbiter must be inferable on a generic plan, not just a custom one."""
+    async with AsyncSessionLocal() as db:
+        user, _ = await get_or_create_user_by_email(db, f"cli-{uuid.uuid4().hex}@example.com")
+        await db.commit()
+    try:
+        results = [await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="box") for _ in range(20)]
+        assert len({r.id for r in results}) == 1
+        assert len({r.full_key for r in results}) == 20
     finally:
         await _cleanup(user.id)

--- a/tests/test_stats_users.py
+++ b/tests/test_stats_users.py
@@ -6,6 +6,7 @@ in a fixed 2020 window and queried over exactly that range, so committed rows fr
 tests (stamped "now") never fall in range and can't pollute the counts.
 """
 
+import uuid
 from datetime import date, datetime
 
 from sqlalchemy import select
@@ -62,7 +63,12 @@ async def _seed() -> None:
 
         u1_api = ApiKey(key=ApiKey.generate_key(), name="dau-u1-api", user_id=user1.id, type=ApiKeyType.api)
         u2_api = ApiKey(key=ApiKey.generate_key(), name="dau-u2-api", user_id=user2.id, type=ApiKeyType.api)
-        u1_cli = ApiKey(key=ApiKey.generate_key(), name="dau-u1-cli", user_id=user1.id, type=ApiKeyType.cli)
+        u1_cli = ApiKey(
+            key=ApiKey.generate_key(),
+            name=f"dau-u1-cli-{uuid.uuid4().hex[:8]}",
+            user_id=user1.id,
+            type=ApiKeyType.cli,
+        )
         u1_chat = ApiKey(key=ApiKey.generate_key(), name="dau-u1-chat", user_id=user1.id, type=ApiKeyType.chat)
         lc_key = ApiKey(
             key=ApiKey.generate_key(),


### PR DESCRIPTION
Groundwork for a "Connected devices" list in the console: before we ship a disconnect button, the database has to guarantee one live CLI key per device.

## Why

`rotate_or_create_cli_api_key` did a SELECT-then-INSERT with nothing serialising it, so two concurrent logins (CLI + Desktop share one config file and one `device_id`) could race and produce two rows with the same `(user_id, name)`. Prod has one such pair today: `libertai-cli@mac-0ec64287`.

The rotate lookup also filters `deleted_at IS NULL`, so once the console can soft-delete a device, every disconnect-then-relogin would mint another same-named row. The duplicate case would go from rare to routine.

## What

- **Partial unique index** `uq_api_keys_cli_user_name` on `api_keys (user_id, name) WHERE type = 'cli' AND deleted_at IS NULL`, declared on both the ORM model and the migration — `tests/conftest.py` builds the schema with `create_all`, not Alembic, so a migration-only index would leave the upsert untestable. Scoped to `cli` because name uniqueness was deliberately dropped for `type=api` in `a1b2c3d4e5f6`.
- **Dedup migration** `a9c47e2b81f0` retires duplicates before creating the index, keeping the row with the most recent `inference_calls.used_at`. The `DESC NULLS LAST` is load-bearing: plain `DESC` is `NULLS FIRST` in Postgres and would rank a never-used row above a used one, retiring the device that actually works.
- **`ON CONFLICT DO UPDATE`** replaces the racy path. `id` and `created_at` survive rotation, so `inference_calls` history stays attached.
- The CLI path now claims a warm *string* rather than a warm *key* — `claim_warm_key` repurposes a pool row via `UPDATE`, which has no `ON CONFLICT` escape and would raise against the new index. Other call sites are untouched.

`index_where` is a raw `text()` literal, not the ORM expression, and that is deliberate — see the comment at `src/services/api_key.py:159-162`. SQLAlchemy renders `ApiKeyDB.type == ApiKeyType.cli` as a bind parameter, and Postgres can only prove partial-index implication against constant nodes: the ORM spelling works on a custom plan and then raises `InvalidColumnReference` once the plan cache goes generic, around the 11th execution on a pooled connection. It would not have failed in tests. `test_cli_key_rotation_survives_repeated_calls` guards it.

## Deploy notes

**One-way.** `downgrade` drops the index but does not un-retire the deduped row. The machine that loses the `mac-0ec64287` tiebreak will need to re-run `libertai login`.

A failed migration takes the API down on every replica (`docker-entrypoint.sh` is `set -e`). If the index build loses a race with an in-flight login from an old replica, re-running is safe — the dedup is idempotent.

## Verification

376 passing (374 before, +2 new). `ruff` clean; `mypy` shows only the pre-existing `dict.get` error in `api_key.py`, shifted from :723 to :706 by the net line delta. Migration applied, downgraded and reapplied against a scratch PG 17.4; the dedup was checked to keep the used row rather than the newer unused one.

After deploy, worth confirming: `libertai login` still rotates in place, and

```sql
SELECT name, count(*) FILTER (WHERE deleted_at IS NULL) AS live, count(*) AS total
FROM api_keys WHERE type='cli' GROUP BY name ORDER BY live DESC;
```

shows the duplicate pair collapsed to one live row.