### PR TITLE
CLI key list: last_used_at and valid-only

### DIFF
--- a/src/interfaces/api_keys.py
+++ b/src/interfaces/api_keys.py
@@ -139,6 +139,12 @@ class FullApiKey(ApiKey):
     full_key: str
 
 
+class CliApiKey(ApiKey):
+    # Most recent metered inference call made with this key. None when the device has
+    # never run inference — `libertai login`, `status` and `keys` leave no trace here.
+    last_used_at: datetime | None = None
+
+
 class ApiKeyListResponse(BaseModel):
     keys: list[FullApiKey]
 

--- a/src/routes/api_keys/api_keys.py
+++ b/src/routes/api_keys/api_keys.py
@@ -12,6 +12,7 @@ from src.interfaces.api_keys import (
     ApiKeyType,
     ApiKeyUpdate,
     ChatApiKeyResponse,
+    CliApiKey,
     CliApiKeyCreate,
     FullApiKey,
     ImageInferenceCallData,
@@ -87,7 +88,7 @@ async def create_cli_api_key(
 
 
 @router.get("/cli")  # type: ignore
-async def get_cli_api_keys(user: User = Depends(get_current_user)) -> list[ApiKey]:
+async def get_cli_api_keys(user: User = Depends(get_current_user)) -> list[CliApiKey]:
     try:
         return await ApiKeyService.get_cli_api_keys(user_id=user.id)
     except Exception as e:

--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -2,13 +2,21 @@ import uuid
 from datetime import datetime, timedelta
 from typing import NamedTuple
 
-from sqlalchemy import select, text
+from sqlalchemy import or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import func as sql_func
 
 from src.config import config
-from src.interfaces.api_keys import ApiKey, ApiKeyType, FullApiKey, InvalidKeyInfo, InvalidKeyReason, invalid_key_info
+from src.interfaces.api_keys import (
+    ApiKey,
+    ApiKeyType,
+    CliApiKey,
+    FullApiKey,
+    InvalidKeyInfo,
+    InvalidKeyReason,
+    invalid_key_info,
+)
 from src.liberclaw_tiers import LIBERCLAW_TIERS
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
@@ -191,25 +199,33 @@ class ApiKeyService:
             raise
 
     @staticmethod
-    async def get_cli_api_keys(user_id: uuid.UUID) -> list[ApiKey]:
-        """List a user's CLI API keys (masked) so they can be reviewed/revoked separately
-        from standard api keys."""
+    async def get_cli_api_keys(user_id: uuid.UUID) -> list[CliApiKey]:
+        """List a user's currently valid CLI API keys (masked), so devices can be reviewed
+        and disconnected separately from standard api keys. Expired and disabled keys are
+        unusable and are omitted."""
+        now = datetime.now()
+        # Correlated max() over the (api_key_id, used_at) index — an index-only backward
+        # scan per key. A GROUP BY join would aggregate the whole inference_calls table.
+        last_used_at = (
+            select(sql_func.max(InferenceCall.used_at))
+            .where(InferenceCall.api_key_id == ApiKeyDB.id)
+            .correlate(ApiKeyDB)
+            .scalar_subquery()
+        )
         async with AsyncSessionLocal() as db:
-            cli_keys = (
-                (
-                    await db.execute(
-                        select(ApiKeyDB).where(
-                            ApiKeyDB.user_id == user_id,
-                            ApiKeyDB.type == ApiKeyType.cli,
-                            ApiKeyDB.deleted_at.is_(None),
-                        )
+            rows = (
+                await db.execute(
+                    select(ApiKeyDB, last_used_at.label("last_used_at")).where(
+                        ApiKeyDB.user_id == user_id,
+                        ApiKeyDB.type == ApiKeyType.cli,
+                        ApiKeyDB.deleted_at.is_(None),
+                        ApiKeyDB.is_active.is_(True),
+                        or_(ApiKeyDB.expires_at.is_(None), ApiKeyDB.expires_at > now),
                     )
                 )
-                .scalars()
-                .all()
-            )
+            ).all()
             return [
-                ApiKey(
+                CliApiKey(
                     id=key.id,
                     key=key.masked_key,
                     name=key.name,
@@ -220,8 +236,9 @@ class ApiKeyService:
                     monthly_limit=key.monthly_limit,
                     type=key.type,
                     expires_at=key.expires_at,
+                    last_used_at=last_used,
                 )
-                for key in cli_keys
+                for key, last_used in rows
             ]
 
     @staticmethod

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from cryptography.fernet import Fernet
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 
 from src.config import config
@@ -17,6 +17,7 @@ from src.interfaces.credits import CreditTransactionProvider, CreditTransactionS
 from src.models.api_key import ApiKey as ApiKeyDB
 from src.models.base import AsyncSessionLocal
 from src.models.credit_transaction import CreditTransaction
+from src.models.inference_call import InferenceCall
 from src.models.user import User
 from src.services.api_key import ApiKeyService
 from src.services.auth_tokens import create_access_token
@@ -219,5 +220,66 @@ async def test_cli_key_rotation_survives_repeated_calls():
         results = [await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="box") for _ in range(20)]
         assert len({r.id for r in results}) == 1
         assert len({r.full_key for r in results}) == 20
+    finally:
+        await _cleanup(user.id)
+
+
+async def test_cli_key_list_reports_last_used():
+    async with AsyncSessionLocal() as db:
+        user, _ = await get_or_create_user_by_email(db, f"cli-{uuid.uuid4().hex}@example.com")
+        await db.commit()
+    try:
+        key = await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="box")
+
+        listed = await ApiKeyService.get_cli_api_keys(user.id)
+        assert len(listed) == 1
+        assert listed[0].last_used_at is None
+
+        async with AsyncSessionLocal() as db:
+            for when in (datetime(2026, 1, 1, 9, 0), datetime(2026, 1, 2, 9, 0)):
+                call = InferenceCall(api_key_id=key.id, credits_used=0.0, model_name="m", input_tokens=0, output_tokens=0)
+                call.used_at = when
+                db.add(call)
+            await db.commit()
+
+        listed = await ApiKeyService.get_cli_api_keys(user.id)
+        assert listed[0].last_used_at == datetime(2026, 1, 2, 9, 0)
+    finally:
+        await _cleanup(user.id)
+
+
+async def test_cli_key_list_omits_expired_and_disabled():
+    async with AsyncSessionLocal() as db:
+        user, _ = await get_or_create_user_by_email(db, f"cli-{uuid.uuid4().hex}@example.com")
+        await db.commit()
+    try:
+        expired = await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="old")
+        disabled = await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="off")
+        await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="live")
+
+        async with AsyncSessionLocal() as db:
+            await db.execute(
+                update(ApiKeyDB).where(ApiKeyDB.id == expired.id).values(expires_at=datetime.now() - timedelta(days=1))
+            )
+            await db.execute(update(ApiKeyDB).where(ApiKeyDB.id == disabled.id).values(is_active=False))
+            await db.commit()
+
+        names = {k.name for k in await ApiKeyService.get_cli_api_keys(user.id)}
+        assert names == {"libertai-cli@live"}
+    finally:
+        await _cleanup(user.id)
+
+
+async def test_cli_key_list_treats_null_expiry_as_valid():
+    async with AsyncSessionLocal() as db:
+        user, _ = await get_or_create_user_by_email(db, f"cli-{uuid.uuid4().hex}@example.com")
+        await db.commit()
+    try:
+        key = await ApiKeyService.rotate_or_create_cli_api_key(user.id, host="forever")
+        async with AsyncSessionLocal() as db:
+            await db.execute(update(ApiKeyDB).where(ApiKeyDB.id == key.id).values(expires_at=None))
+            await db.commit()
+
+        assert len(await ApiKeyService.get_cli_api_keys(user.id)) == 1
     finally:
         await _cleanup(user.id)


### PR DESCRIPTION
Second and final backend change for the console's upcoming "Connected devices" list. Read-path only — `rotate_or_create_cli_api_key` is untouched.

Follows #63, which is merged and deployed.

## What

`GET /api-keys/cli` now:

- **returns only currently valid keys** — `is_active` AND (`expires_at IS NULL` OR not yet expired)
- **carries `last_used_at`** per key, the most recent `inference_calls.used_at`

New `CliApiKey(ApiKey)` adds the one field. The endpoint still returns a **bare array**, deliberately: no envelope means the console and backend can deploy in either order without the frontend having to guess at a missing wrapper.

## Notes for review

**Expiry has to be checked, not just the flag.** Nothing writes back `is_active` when a key lapses, so prod currently holds `libertai-cli@local` — `is_active = true`, expired 2026-07-04 under the old 30-day TTL. Filtering on the flag alone would have shown it in the UI as a connected device a month after it stopped working. `expires_at IS NULL` still counts as valid.

**`last_used_at` is a correlated scalar subquery, not a `GROUP BY` join.** The join form aggregates the whole `inference_calls` table however few devices the user has; the correlated form is an index-only backward scan per key over the existing `ix_inference_calls_api_key_id_used_at`.

**"Last used" means metered inference only.** `libertai login`, `status`, `keys` and friends leave no `inference_calls` row, so a freshly connected device reports `None`. The console renders that as "No requests yet" rather than "Never used", which would otherwise sit next to a Disconnect button on a device connected minutes earlier.

## Verification

379 passing (376 before, +3). mypy zero errors, ruff clean. Three new tests cover: `last_used_at` is the max of several calls and `None` with no calls; expired and disabled keys excluded; null expiry treated as valid.