### PR TITLE
fix(entitlement): treat sub-epsilon window room as exhausted

### DIFF
--- a/src/services/api_key.py
+++ b/src/services/api_key.py
@@ -36,6 +36,7 @@ from src.services.entitlement import (
     get_allowance_state,
     month_overflow_by_users,
     open_windows,
+    remaining_allowance,
     window_usage_by_users,
 )
 from src.subscription_tiers import DEFAULT_TIER, get_tier
@@ -825,8 +826,8 @@ class ApiKeyService:
                     await open_windows(db, chargeable_user_id, now)
                     # Billing split only needs the window fields — skip the cap queries.
                     state = await get_allowance_state(db, chargeable_user_id, now, include_cap=False)
-                    remaining_5h = max(0.0, state.window_5h_limit - state.window_5h_used)
-                    remaining_weekly = max(0.0, state.weekly_limit - state.weekly_used)
+                    remaining_5h = remaining_allowance(state.window_5h_limit, state.window_5h_used)
+                    remaining_weekly = remaining_allowance(state.weekly_limit, state.weekly_used)
                     tier_covered = min(credits_used, remaining_5h, remaining_weekly)
 
                 # Liberclaw keys: usage overflowing the tier's rolling-window cap is paid

--- a/src/services/entitlement.py
+++ b/src/services/entitlement.py
@@ -40,6 +40,10 @@ from src.subscription_tiers import DEFAULT_TIER, TierConfig, get_tier
 # are exhausted (matches the legacy gateway threshold).
 PREPAID_MIN = 0.02
 
+# Window room at or below this counts as none left: float8 usage sums drift ~1e-12
+# around their cap. Stays below the cheapest billable call (1e-5).
+CREDIT_EPSILON = 1e-6
+
 # Fixed window kinds and their durations.
 WINDOW_5H = "5h"
 WINDOW_WEEKLY = "weekly"
@@ -86,9 +90,20 @@ class AllowanceState:
     extra_credits_used_this_month: float = 0.0
 
 
+def remaining_allowance(limit: float, used: float) -> float:
+    """Spendable room left in a window. Gate and billing split must both use this:
+    room the gate honours but the split rounds to zero stops usage accruing, so the
+    window never closes."""
+    remaining = limit - used
+    return remaining if remaining > CREDIT_EPSILON else 0.0
+
+
 def compute_source(tier: TierConfig, usage_5h: float, usage_weekly: float, prepaid: float) -> str:
     """Decide which path covers the *next* call: tier window, prepaid, or none."""
-    within_window = usage_5h < tier.window_5h_credits and usage_weekly < tier.weekly_credits
+    within_window = (
+        remaining_allowance(tier.window_5h_credits, usage_5h) > 0.0
+        and remaining_allowance(tier.weekly_credits, usage_weekly) > 0.0
+    )
     if within_window:
         return "tier"
     if prepaid >= PREPAID_MIN:

--- a/tests/test_entitlement.py
+++ b/tests/test_entitlement.py
@@ -1,5 +1,6 @@
 """Fixed-window entitlement: windows accrue then reset to 0 on expiry (not rolling)."""
 
+import math
 import uuid
 from datetime import datetime, timedelta
 
@@ -14,7 +15,16 @@ from src.models.entitlement_window import EntitlementWindow
 from src.models.inference_call import InferenceCall
 from src.models.plan_subscription import PlanSubscription
 from src.models.user import User
-from src.services.entitlement import WINDOW_5H, WINDOW_WEEKLY, get_allowance_state, open_windows, window_usage_by_users
+from src.services.entitlement import (
+    WINDOW_5H,
+    WINDOW_WEEKLY,
+    compute_source,
+    get_allowance_state,
+    open_windows,
+    remaining_allowance,
+    window_usage_by_users,
+)
+from src.subscription_tiers import get_tier
 
 NOW = datetime(2026, 6, 3, 12, 0, 0)
 
@@ -180,3 +190,34 @@ async def test_chat_key_usage_counts_in_window(db):
     state = await get_allowance_state(db, user.id, now=NOW)
     assert state.weekly_used == pytest.approx(1.5)
     assert state.window_5h_used == pytest.approx(1.5)
+
+
+def test_usage_one_ulp_below_cap_counts_as_exhausted():
+    """A saturated window's float8 usage sum lands an ULP either side of its cap."""
+    tier = get_tier("free")
+    assert compute_source(tier, 0.0, math.nextafter(tier.weekly_credits, 0.0), 0.0) == "blocked"
+    assert compute_source(tier, math.nextafter(tier.window_5h_credits, 0.0), 0.0, 0.0) == "blocked"
+
+
+def test_real_remaining_room_still_grants_tier_coverage():
+    tier = get_tier("free")
+    # 0.0001 credits left is a spendable amount, not float noise.
+    assert compute_source(tier, 0.0, tier.weekly_credits - 0.0001, 0.0) == "tier"
+
+
+def test_remaining_allowance_snaps_float_noise_to_zero():
+    assert remaining_allowance(2.0, math.nextafter(2.0, 0.0)) == 0.0
+    assert remaining_allowance(2.0, 2.0) == 0.0
+    assert remaining_allowance(2.0, 2.5) == 0.0
+    assert remaining_allowance(2.0, 1.75) == pytest.approx(0.25)
+
+
+@pytest.mark.asyncio
+async def test_saturated_weekly_window_blocks_through_query_path(db):
+    user = await _user(db)
+    key = await _api_key(db, user.id)
+    await _window(db, user.id, WINDOW_WEEKLY, started_at=NOW - timedelta(days=1), expires_at=NOW + timedelta(days=6))
+    await _use(db, key.id, math.nextafter(2.0, 0.0), NOW - timedelta(hours=1))
+
+    state = await get_allowance_state(db, user.id, now=NOW)
+    assert state.source == "blocked"


### PR DESCRIPTION
## Problem

A user whose free-tier window was fully consumed kept getting unlimited free inference.

The billing split hands the last tier-covered call exactly the remaining allowance, so a saturated window's `SUM(tier_credits_used)` targets its cap exactly. But it's a `float8` aggregate over thousands of rows, so it lands an ULP either side of the cap — in prod, `1.9999999999999996` against a `2.0` weekly cap.

That's below the cap, so `compute_source` returned `"tier"` and the key stayed in the whitelist. Meanwhile the split computed `remaining = 4.4e-16` and wrote `tier_credits_used = 0`. The sum stopped growing, so the window never closed:

```
gate:  1.9999999999999996 < 2.0  ->  key valid
split: remaining 4.4e-16         ->  tier_credits_used = 0  ->  sum never moves
```

Every call then went entirely to overflow, charged against an empty prepaid balance. `use_credits(..., allow_partial=True)` captures what it can and logs a warning otherwise, so nothing stopped it.

Prod impact: one account made **2801 calls over ~20h** after saturating its 2.0/week allowance, for **36.20 unpaid credits**. Three accounts affected, 37.23 credits total.

## Fix

One shared definition of "this window is exhausted", used by both the gate and the billing split — they have to agree, since room the gate honours but the split rounds to zero is exactly what stalls the sum.

```python
CREDIT_EPSILON = 1e-6

def remaining_allowance(limit: float, used: float) -> float:
    remaining = limit - used
    return remaining if remaining > CREDIT_EPSILON else 0.0
```

On `1e-6`: max float drift over ~3000 rows is ~1e-12, so there's 6 orders of magnitude of headroom. It's also 10x below the cheapest billable call seen in prod (`1e-5`), so it can never deny a call the allowance could still fund.

## Tests

3 regression tests, all failing with `CREDIT_EPSILON = 0.0`. Full suite green (383 passed) on `postgres:17.4-alpine3.21`, matching prod.

## Follow-ups (not in this PR)

- The gate is still the only defense. When the overflow deduction falls short, a `logger.warning` isn't enough — the key should be invalidated or a debt recorded.
- Money columns are `float8`. `SUM(float8)` is also plan-dependent, so two code paths summing the same rows can disagree across a threshold. `numeric` is the real answer, but it's a refactor of the billing path, not a migration.
